### PR TITLE
Method name typo

### DIFF
--- a/contracts/Lockbox.cdc
+++ b/contracts/Lockbox.cdc
@@ -329,7 +329,7 @@ pub contract Lockbox {
 
             let vaultRef = tokenManagerRef.vault.borrow()!
 
-            tokenManagerRef.nodeDelegator?.delegatorNewTokens(from: <-vaultRef.withdraw(amount: amount))
+            tokenManagerRef.nodeDelegator?.delegateNewTokens(from: <-vaultRef.withdraw(amount: amount))
         }
 
         /// Delegate tokens from the unlocked staking bucket


### PR DESCRIPTION
Fix typo in name of the method available on `NodeDelegator`