### PR TITLE
Update all templates to use common Environment param

### DIFF
--- a/lib/go/templates/delegator_templates.go
+++ b/lib/go/templates/delegator_templates.go
@@ -23,88 +23,88 @@ const (
 	getDelegatorRequestFilename   = "idTableStaking/delegation/get_delegator_request.cdc"
 )
 
-func GenerateCreateDelegationScript(idTableAddr string) []byte {
+func GenerateCreateDelegationScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + createDelegationFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateRegisterDelegatorScript(idTableAddr string) []byte {
+func GenerateRegisterDelegatorScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegatorRegisterFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDelegatorStakeNewScript(ftAddress, flowAddr, idTableAddr string) []byte {
+func GenerateDelegatorStakeNewScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegatorStakeNewFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddress, flowAddr, idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDelegatorStakeUnstakedScript(idTableAddr string) []byte {
+func GenerateDelegatorStakeUnstakedScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegatorStakeUnstakedFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDelegatorStakeRewardedScript(idTableAddr string) []byte {
+func GenerateDelegatorStakeRewardedScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegatorStakeRewardedFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDelegatorRequestUnstakeScript(idTableAddr string) []byte {
+func GenerateDelegatorRequestUnstakeScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegatorRequestUnstakeFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDelegatorWithdrawUnstakedScript(ftAddress, flowAddr, idTableAddr string) []byte {
+func GenerateDelegatorWithdrawUnstakedScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegatorWithdrawUnstakedFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddress, flowAddr, idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDelegatorWithdrawRewardsScript(ftAddress, flowAddr, idTableAddr string) []byte {
+func GenerateDelegatorWithdrawRewardsScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegatorWithdrawRewardsFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddress, flowAddr, idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-/// Scripts
+// Scripts
 
-func GenerateGetDelegatorCommittedScript(idTableAddr string) []byte {
+func GenerateGetDelegatorCommittedScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getDelegatorCommittedFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetDelegatorStakedScript(idTableAddr string) []byte {
+func GenerateGetDelegatorStakedScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getDelegatorStakedFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetDelegatorUnstakingScript(idTableAddr string) []byte {
+func GenerateGetDelegatorUnstakingScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getDelegatorUnstakingFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetDelegatorUnstakedScript(idTableAddr string) []byte {
+func GenerateGetDelegatorUnstakedScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getDelegatorUnstakedFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetDelegatorRewardsScript(idTableAddr string) []byte {
+func GenerateGetDelegatorRewardsScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getDelegatorRewardedFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetDelegatorRequestScript(idTableAddr string) []byte {
+func GenerateGetDelegatorRequestScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getDelegatorRequestFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }

--- a/lib/go/templates/idtable_staking_templates.go
+++ b/lib/go/templates/idtable_staking_templates.go
@@ -44,241 +44,241 @@ const (
 
 // GenerateTransferMinterAndDeployScript generates a script that transfers
 // a flow minter and deploys the id table account
-func GenerateTransferMinterAndDeployScript(ftAddr, flowAddr string) []byte {
+func GenerateTransferMinterAndDeployScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + transferDeployFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddr, flowAddr, ""))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateReturnTableScript creates a script that returns
 // the the whole ID table nodeIDs
-func GenerateReturnTableScript(ftAddr, flowAddr, idTableAddr string) []byte {
+func GenerateReturnTableScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getTableFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddr, flowAddr, idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateReturnCurrentTableScript creates a script that returns
 // the current ID table
-func GenerateReturnCurrentTableScript(ftAddr, flowAddr, idTableAddr string) []byte {
+func GenerateReturnCurrentTableScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + currentTableFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddr, flowAddr, idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateReturnProposedTableScript creates a script that returns
 // the ID table for the proposed next epoch
-func GenerateReturnProposedTableScript(ftAddr, flowAddr, idTableAddr string) []byte {
+func GenerateReturnProposedTableScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + proposedTableFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddr, flowAddr, idTableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateCreateNodeScript creates a script that creates a new
 // node struct and stores it in the Node records
-func GenerateCreateNodeScript(ftAddr, flowAddr, tableAddr string) []byte {
+func GenerateCreateNodeScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + createNodeStructFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddr, flowAddr, tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateRemoveNodeScript creates a script that removes a node
 // from the record
-func GenerateRemoveNodeScript(tableAddr string) []byte {
+func GenerateRemoveNodeScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + removeNodeFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateEndStakingScript creates a script that ends the staking auction
-func GenerateEndStakingScript(tableAddr string) []byte {
+func GenerateEndStakingScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + endStakingFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GeneratePayRewardsScript creates a script that pays rewards
-func GeneratePayRewardsScript(tableAddr string) []byte {
+func GeneratePayRewardsScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + payRewardsFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateMoveTokensScript creates a script that moves tokens between buckets
-func GenerateMoveTokensScript(tableAddr string) []byte {
+func GenerateMoveTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + moveTokensFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateStakeNewTokensScript creates a script that stakes new
 // tokens for a node operator
-func GenerateStakeNewTokensScript(ftAddr, flowAddr, tableAddr string) []byte {
+func GenerateStakeNewTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + stakeNewTokensFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddr, flowAddr, tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateStakeUnstakedTokensScript creates a script that stakes
 // tokens for a node operator from their unstaked bucket
-func GenerateStakeUnstakedTokensScript(tableAddr string) []byte {
+func GenerateStakeUnstakedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + stakeUnstakedTokensFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateStakeRewardedTokensScript creates a script that stakes
 // tokens for a node operator from their rewarded bucket
-func GenerateStakeRewardedTokensScript(tableAddr string) []byte {
+func GenerateStakeRewardedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + stakeRewardedTokensFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateUnstakeTokensScript creates a script that makes an unstaking request
 // for an existing node operator
-func GenerateUnstakeTokensScript(tableAddr string) []byte {
+func GenerateUnstakeTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + unstakeTokensFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateWithdrawUnstakedTokensScript creates a script that withdraws unstaked tokens
 // for an existing node operator
-func GenerateWithdrawUnstakedTokensScript(ftAddr, flowAddr, tableAddr string) []byte {
+func GenerateWithdrawUnstakedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + withdrawUnstakedTokensFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddr, flowAddr, tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateWithdrawRewardedTokensScript creates a script that withdraws rewarded tokens
 // for an existing node operator
-func GenerateWithdrawRewardedTokensScript(ftAddr, flowAddr, tableAddr string) []byte {
+func GenerateWithdrawRewardedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + withdrawRewardedTokensFilename)
 
-	return []byte(ReplaceAddresses(code, ftAddr, flowAddr, tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetRoleScript creates a script
 // that returns the role of a node
-func GenerateGetRoleScript(tableAddr string) []byte {
+func GenerateGetRoleScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getRoleFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetNetworkingAddressScript creates a script
 // that returns the networking address of a node
-func GenerateGetNetworkingAddressScript(tableAddr string) []byte {
+func GenerateGetNetworkingAddressScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getNetworkingAddrFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetNetworkingKeyScript creates a script
 // that returns the networking key of a node
-func GenerateGetNetworkingKeyScript(tableAddr string) []byte {
+func GenerateGetNetworkingKeyScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getNetworkingKeyFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetStakingKeyScript creates a script
 // that returns the staking key of a node
-func GenerateGetStakingKeyScript(tableAddr string) []byte {
+func GenerateGetStakingKeyScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getStakingKeyFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetInitialWeightScript creates a script
 // that returns the initial weight of a node
-func GenerateGetInitialWeightScript(tableAddr string) []byte {
+func GenerateGetInitialWeightScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getInitialWeightFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetStakedBalanceScript creates a script
 // that returns the balance of the staked tokens of a node
-func GenerateGetStakedBalanceScript(tableAddr string) []byte {
+func GenerateGetStakedBalanceScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + stakedBalanceFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetCommittedBalanceScript creates a script
 // that returns the balance of the committed tokens of a node
-func GenerateGetCommittedBalanceScript(tableAddr string) []byte {
+func GenerateGetCommittedBalanceScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + comittedBalanceFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetUnstakingBalanceScript creates a script
 // that returns the balance of the unstaking tokens of a node
-func GenerateGetUnstakingBalanceScript(tableAddr string) []byte {
+func GenerateGetUnstakingBalanceScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + unstakingBalanceFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetUnstakedBalanceScript creates a script
 // that returns the balance of the unstaked tokens of a node
-func GenerateGetUnstakedBalanceScript(tableAddr string) []byte {
+func GenerateGetUnstakedBalanceScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + unstakedBalanceFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetRewardBalanceScript creates a script
 // that returns the balance of the rewarded tokens of a node
-func GenerateGetRewardBalanceScript(tableAddr string) []byte {
+func GenerateGetRewardBalanceScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + rewardBalanceFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetUnstakingRequestScript creates a script
 // that returns the balance of the unstaking request for a node
-func GenerateGetUnstakingRequestScript(tableAddr string) []byte {
+func GenerateGetUnstakingRequestScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getUnstakingRequestFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetTotalCommitmentBalanceScript creates a script
 // that returns the balance of the total committed tokens of a node
-func GenerateGetTotalCommitmentBalanceScript(tableAddr string) []byte {
+func GenerateGetTotalCommitmentBalanceScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getTotalCommitmentFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetStakeRequirementsScript returns the stake requirement for a node type
-func GenerateGetStakeRequirementsScript(tableAddr string) []byte {
+func GenerateGetStakeRequirementsScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + stakeRequirementsFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetTotalTokensStakedByTypeScript returns the total tokens staked for a node type
-func GenerateGetTotalTokensStakedByTypeScript(tableAddr string) []byte {
+func GenerateGetTotalTokensStakedByTypeScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + totalStakedFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetRewardRatioScript gets the reward ratio for a node type
-func GenerateGetRewardRatioScript(tableAddr string) []byte {
+func GenerateGetRewardRatioScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + rewardRatioFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateGetWeeklyPayoutScript gets the total weekly reward payout
-func GenerateGetWeeklyPayoutScript(tableAddr string) []byte {
+func GenerateGetWeeklyPayoutScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + weeklyPayoutFilename)
 
-	return []byte(ReplaceAddresses(code, "", "", tableAddr))
+	return []byte(replaceAddresses(code, env))
 }

--- a/lib/go/templates/lockbox_templates.go
+++ b/lib/go/templates/lockbox_templates.go
@@ -52,304 +52,222 @@ func GenerateDeployLockedTokens() []byte {
 	return assets.MustAsset(filePath + deployLockedTokensFilename)
 }
 
-func GenerateCreateSharedAccountScript(ftAddr, flowTokenAddr, lockedTokensAddr string) []byte {
+func GenerateCreateSharedAccountScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + createLockedAccountsFilename)
 
-	code = ReplaceAddresses(code, ftAddr, flowTokenAddr, "")
-
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDepositLockedTokensScript(ftAddr, flowTokenAddr, lockedTokensAddr string) []byte {
+func GenerateDepositLockedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + depositLockedTokensFilename)
 
-	code = ReplaceAddresses(code, ftAddr, flowTokenAddr, "")
-
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateIncreaseUnlockLimitScript(lockedTokensAddr string) []byte {
+func GenerateIncreaseUnlockLimitScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + increaseUnlockLimitFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDepositAccountCreatorScript(lockedTokensAddr string) []byte {
+func GenerateDepositAccountCreatorScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + depositAccountCreatorCapabilityFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
 /************ Custody Provider Transactions ********************/
 
-func GenerateSetupCustodyAccountScript(lockedTokensAddr string) []byte {
+func GenerateSetupCustodyAccountScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + setupCustodyAccountFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateCustodyCreateAccountsScript(ftAddr, flowTokenAddr, lockedTokensAddr string) []byte {
+func GenerateCustodyCreateAccountsScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + custodyCreateAccountsFilename)
 
-	code = ReplaceAddresses(code, ftAddr, flowTokenAddr, "")
-
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateCustodyCreateOnlySharedAccountScript(ftAddr, flowTokenAddr, lockedTokensAddr string) []byte {
+func GenerateCustodyCreateOnlySharedAccountScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + custodyCreateOnlySharedAccountFilename)
 
-	code = ReplaceAddresses(code, ftAddr, flowTokenAddr, "")
-
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
 /************ User Transactions ********************/
 
-func GenerateWithdrawTokensScript(ftAddr, flowTokenAddr, lockedTokensAddr string) []byte {
+func GenerateWithdrawTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + withdrawTokensFilename)
 
-	code = ReplaceAddresses(code, ftAddr, flowTokenAddr, "")
-
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateDepositTokensScript(ftAddr, flowTokenAddr, lockedTokensAddr string) []byte {
+func GenerateDepositTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + depositTokensFilename)
 
-	code = ReplaceAddresses(code, ftAddr, flowTokenAddr, "")
-
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetLockedAccountAddressScript(lockedTokensAddr string) []byte {
+func GenerateGetLockedAccountAddressScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getLockedAccountAddressFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetLockedAccountBalanceScript(lockedTokensAddr string) []byte {
+func GenerateGetLockedAccountBalanceScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getLockedAccountBalanceFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetUnlockLimitScript(lockedTokensAddr string) []byte {
+func GenerateGetUnlockLimitScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getUnlockLimitFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
 /************ Node Staker Transactions ******************/
 
 // CreateLockedNodeScript creates a script that creates a new
 // node request with locked tokens.
-func GenerateCreateLockedNodeScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateCreateLockedNodeScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + createLockedNodeFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // StakeNewLockedTokensScript creates a script that stakes new
 // locked tokens.
-func GenerateStakeNewLockedTokensScript(
-	fungibleTokenAddr,
-	flowTokenAddr,
-	lockedTokensAddr,
-	proxyAddr string,
-) []byte {
+func GenerateStakeNewLockedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + stakeNewLockedTokensFilename)
 
-	code = ReplaceAddresses(code, fungibleTokenAddr, flowTokenAddr, "")
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // StakeLockedUnstakedTokensScript creates a script that stakes
 // unstaked tokens.
 // The unusual name is to avoid a clash with idtables_staking_templates.go .
-func GenerateStakeLockedUnstakedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateStakeLockedUnstakedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + stakeLockedUnstakedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // StakeLockedRewardedTokensScript creates a script that stakes
 // unstaked tokens.
 // The unusual name is to avoid a clash with idtables_staking_templates.go .
-func GenerateStakeLockedRewardedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateStakeLockedRewardedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + stakeLockedRewardedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // UnstakeLockedTokensScript creates a script that unstakes
 // locked tokens.
-func GenerateUnstakeLockedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateUnstakeLockedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + unstakeLockedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // UnstakeAllLockedTokensScript creates a script that unstakes
 // all locked tokens.
-func GenerateUnstakeAllLockedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateUnstakeAllLockedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + unstakeAllLockedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // WithdrawLockedUnstakedTokensScript creates a script that requests
 // a withdrawal of unstaked tokens.
 // The unusual name is to avoid a clash with idtables_staking_templates.go .
-func GenerateWithdrawLockedUnstakedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateWithdrawLockedUnstakedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + withdrawLockedUnstakedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // WithdrawLockedRewardedTokensScript creates a script that requests
 // a withdrawal of unstaked tokens.
 // The unusual name is to avoid a clash with idtables_staking_templates.go .
-func GenerateWithdrawLockedRewardedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateWithdrawLockedRewardedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + withdrawLockedRewardedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetNodeIDScript(lockedTokensAddr string) []byte {
+func GenerateGetNodeIDScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getNodeIDFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }
 
 /******************** Delegator Transactions ****************************/
 
 // CreateLockedDelegatorScript creates a script that creates a new
 // node request with locked tokens.
-func GenerateCreateLockedDelegatorScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateCreateLockedDelegatorScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + registerLockedDelegatorFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // DelegateNewLockedTokensScript creates a script that stakes new
 // locked tokens.
-func GenerateDelegateNewLockedTokensScript(
-	fungibleTokenAddr,
-	flowTokenAddr,
-	lockedTokensAddr,
-	proxyAddr string,
-) []byte {
+func GenerateDelegateNewLockedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegateNewLockedTokensFilename)
 
-	code = ReplaceAddresses(code, fungibleTokenAddr, flowTokenAddr, "")
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // DelegateLockedUnstakedTokensScript creates a script that stakes
 // unstaked tokens.
 // The unusual name is to avoid a clash with idtables_staking_templates.go .
-func GenerateDelegateLockedUnstakedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateDelegateLockedUnstakedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegateLockedUnstakedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // DelegateLockedRewardedTokensScript creates a script that stakes
 // unstaked tokens.
 // The unusual name is to avoid a clash with idtables_staking_templates.go .
-func GenerateDelegateLockedRewardedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateDelegateLockedRewardedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + delegateLockedRewardedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // UnDelegateLockedTokensScript creates a script that unstakes
 // locked tokens.
-func GenerateUnDelegateLockedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateUnDelegateLockedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + requestUnstakingLockedDelegatedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // WithdrawDelegatorLockedUnstakedTokensScript creates a script that requests
 // a withdrawal of unstaked tokens.
 // The unusual name is to avoid a clash with idtables_staking_templates.go .
-func GenerateWithdrawDelegatorLockedUnstakedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateWithdrawDelegatorLockedUnstakedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + withdrawLockedUnstakedDelegatedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // WithdrawDelegatorLockedRewardedTokensScript creates a script that requests
 // a withdrawal of unstaked tokens.
 // The unusual name is to avoid a clash with idtables_staking_templates.go .
-func GenerateWithdrawDelegatorLockedRewardedTokensScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateWithdrawDelegatorLockedRewardedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + withdrawLockedRewardedDelegatedTokensFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetDelegatorIDScript(lockedTokensAddr string) []byte {
+func GenerateGetDelegatorIDScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getDelegatorIDFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(code)
+	return []byte(replaceAddresses(code, env))
 }

--- a/lib/go/templates/manifest/main.go
+++ b/lib/go/templates/manifest/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/lib/go/templates/service_templates.go
+++ b/lib/go/templates/service_templates.go
@@ -1,7 +1,5 @@
 package templates
 
-//go:generate go run github.com/kevinburke/go-bindata/go-bindata -prefix ../../../transactions/... -o internal/assets/assets.go -pkg assets -nometadata -nomemcopy ../../../transactions/...
-
 import (
 	"strings"
 

--- a/lib/go/templates/stakingProxy_templates.go
+++ b/lib/go/templates/stakingProxy_templates.go
@@ -26,80 +26,78 @@ const (
 
 // GenerateSetupNodeAccountScript generates a script that sets up
 // a node operator's account to receive staking proxies
-func GenerateSetupNodeAccountScript(proxyAddr string) []byte {
+func GenerateSetupNodeAccountScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + setupNodeAccountFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // GenerateAddNodeInfoScript generates a script that adds the node
 // operators node info to their account
-func GenerateAddNodeInfoScript(proxyAddr string) []byte {
+func GenerateAddNodeInfoScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + addNodeInfoFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateRemoveNodeInfoScript(proxyAddr string) []byte {
+func GenerateRemoveNodeInfoScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + removeNodeInfoFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateGetNodeInfoScript(proxyAddr string) []byte {
+func GenerateGetNodeInfoScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + getNodeInfoFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateRemoveStakingProxyScript(proxyAddr string) []byte {
+func GenerateRemoveStakingProxyScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + removeStakingProxyFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateProxyStakeNewTokensScript(proxyAddr string) []byte {
+func GenerateProxyStakeNewTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + proxyStakeNewTokensFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateProxyStakeUnstakedTokensScript(proxyAddr string) []byte {
+func GenerateProxyStakeUnstakedTokensScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + proxyStakeUnstakedTokensFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateProxyRequestUnstakingScript(proxyAddr string) []byte {
+func GenerateProxyRequestUnstakingScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + proxyRequestUnstakingFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateProxyUnstakeAllScript(proxyAddr string) []byte {
+func GenerateProxyUnstakeAllScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + proxyUnstakeAllFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateProxyWithdrawRewardsScript(proxyAddr string) []byte {
+func GenerateProxyWithdrawRewardsScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + proxyWithdrawRewardsFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
-func GenerateProxyWithdrawUnstakedScript(proxyAddr string) []byte {
+func GenerateProxyWithdrawUnstakedScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + proxyWithdrawUnstakedFilename)
 
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }
 
 // Transactions for the token holder
 
-func GenerateRegisterStakingProxyNodeScript(lockedTokensAddr, proxyAddr string) []byte {
+func GenerateRegisterStakingProxyNodeScript(env Environment) []byte {
 	code := assets.MustAssetString(filePath + registerNodeFilename)
 
-	code = ReplaceLockedTokensAddress(code, lockedTokensAddr)
-
-	return []byte(ReplaceStakingProxyAddress(code, proxyAddr))
+	return []byte(replaceAddresses(code, env))
 }

--- a/lib/go/templates/templates.go
+++ b/lib/go/templates/templates.go
@@ -1,5 +1,7 @@
 package templates
 
+//go:generate go run github.com/kevinburke/go-bindata/go-bindata -prefix ../../../transactions/... -o internal/assets/assets.go -pkg assets -nometadata -nomemcopy ../../../transactions/...
+
 import (
 	"fmt"
 	"strings"
@@ -9,9 +11,17 @@ const (
 	placeholderFungibleTokenAddress = "0xFUNGIBLETOKENADDRESS"
 	placeholderFlowTokenAddress     = "0xFLOWTOKENADDRESS"
 	placeholderIDTableAddress       = "0xIDENTITYTABLEADDRESS"
-	placeholderStakingProxyAddress  = "0xSTAKINGPROXYADDRESS"
 	placeholderLockedTokensAddress  = "0xLOCKEDTOKENADDRESS"
+	placeholderStakingProxyAddress  = "0xSTAKINGPROXYADDRESS"
 )
+
+type Environment struct {
+	FungibleTokenAddress string
+	FlowTokenAddress     string
+	IDTableAddress       string
+	LockedTokensAddress  string
+	StakingProxyAddress  string
+}
 
 func withHexPrefix(address string) string {
 	if address == "" {
@@ -25,57 +35,36 @@ func withHexPrefix(address string) string {
 	return fmt.Sprintf("0x%s", address)
 }
 
-// ReplaceAddresses replaces the import address
-// and phase in scripts that return info about a specific node and phase
-func ReplaceAddresses(
-	code,
-	fungibleTokenAddress,
-	flowTokenAddress,
-	idTableAddress string,
-) string {
+func replaceAddresses(code string, env Environment) string {
 
 	code = strings.ReplaceAll(
 		code,
 		placeholderFungibleTokenAddress,
-		withHexPrefix(fungibleTokenAddress),
+		withHexPrefix(env.FungibleTokenAddress),
 	)
 
 	code = strings.ReplaceAll(
 		code,
 		placeholderFlowTokenAddress,
-		withHexPrefix(flowTokenAddress),
+		withHexPrefix(env.FlowTokenAddress),
 	)
 
 	code = strings.ReplaceAll(
 		code,
 		placeholderIDTableAddress,
-		withHexPrefix(idTableAddress),
+		withHexPrefix(env.IDTableAddress),
 	)
-
-	return code
-}
-
-// ReplaceStakingProxyAddress replaces the import address
-// and phase in scripts that use staking proxy contract
-func ReplaceStakingProxyAddress(code, proxyAddress string) string {
-
-	code = strings.ReplaceAll(
-		code,
-		placeholderStakingProxyAddress,
-		withHexPrefix(proxyAddress),
-	)
-
-	return code
-}
-
-// ReplaceLockedTokensAddress replaces the import address
-// and phase in scripts that return info about a specific node and phase.
-func ReplaceLockedTokensAddress(code, lockedTokensAddress string) string {
 
 	code = strings.ReplaceAll(
 		code,
 		placeholderLockedTokensAddress,
-		withHexPrefix(lockedTokensAddress),
+		withHexPrefix(env.LockedTokensAddress),
+	)
+
+	code = strings.ReplaceAll(
+		code,
+		placeholderStakingProxyAddress,
+		withHexPrefix(env.StakingProxyAddress),
 	)
 
 	return code


### PR DESCRIPTION
This makes it a bit easier to manage all of the contract addresses passed into our transaction templates, and also serves as pre-work for a script I'm writing to generate templates hashes and test cases for the Ledger app.