### PR TITLE
Update template manifest to use locked delegator registration script

### DIFF
--- a/lib/go/templates/manifest.mainnet.json
+++ b/lib/go/templates/manifest.mainnet.json
@@ -187,7 +187,7 @@
     {
       "id": "TH.17",
       "name": "Register Delegator",
-      "source": "import FlowIDTableStaking from 0x8624b52f9ddcd04a\n\ntransaction(nodeID: String) {\n\n    prepare(acct: AuthAccount) {\n\n        // Create a new delegator object for the node\n        let newDelegator \u003c- FlowIDTableStaking.registerNewDelegator(nodeID: nodeID)\n\n        // Store the delegator object\n        acct.save(\u003c-newDelegator, to: FlowIDTableStaking.DelegatorStoragePath)\n    }\n\n}",
+      "source": "import LockedTokens from 0x8d0e87b65159ae63\n\ntransaction(id: String, amount: UFix64) {\n\n    let holderRef: \u0026LockedTokens.TokenHolder\n\n    prepare(account: AuthAccount) {\n        self.holderRef = account.borrow\u003c\u0026LockedTokens.TokenHolder\u003e(from: LockedTokens.TokenHolderStoragePath) \n            ?? panic(\"TokenHolder is not saved at specified path\")\n    }\n\n    execute {\n        self.holderRef.createNodeDelegator(nodeID: id)\n\n        let delegatorProxy = self.holderRef.borrowDelegator()\n\n        delegatorProxy.delegateNewTokens(amount: amount)\n    }\n}\n",
       "arguments": [
         {
           "type": "String",
@@ -201,7 +201,7 @@
         }
       ],
       "network": "mainnet",
-      "hash": "94a37cfffbd452d6139967282862be747297c60f9f0c78b1bb2c27c59cb9dbf6"
+      "hash": "90068c2742d17ba5ce1b34dba02bd0e4db0c38fc943bf57008c3f973b30fbb2c"
     },
     {
       "id": "TH.19",

--- a/lib/go/templates/manifest.testnet.json
+++ b/lib/go/templates/manifest.testnet.json
@@ -187,7 +187,7 @@
     {
       "id": "TH.17",
       "name": "Register Delegator",
-      "source": "import FlowIDTableStaking from 0x9eca2b38b18b5dfe\n\ntransaction(nodeID: String) {\n\n    prepare(acct: AuthAccount) {\n\n        // Create a new delegator object for the node\n        let newDelegator \u003c- FlowIDTableStaking.registerNewDelegator(nodeID: nodeID)\n\n        // Store the delegator object\n        acct.save(\u003c-newDelegator, to: FlowIDTableStaking.DelegatorStoragePath)\n    }\n\n}",
+      "source": "import LockedTokens from 0x95e019a17d0e23d7\n\ntransaction(id: String, amount: UFix64) {\n\n    let holderRef: \u0026LockedTokens.TokenHolder\n\n    prepare(account: AuthAccount) {\n        self.holderRef = account.borrow\u003c\u0026LockedTokens.TokenHolder\u003e(from: LockedTokens.TokenHolderStoragePath) \n            ?? panic(\"TokenHolder is not saved at specified path\")\n    }\n\n    execute {\n        self.holderRef.createNodeDelegator(nodeID: id)\n\n        let delegatorProxy = self.holderRef.borrowDelegator()\n\n        delegatorProxy.delegateNewTokens(amount: amount)\n    }\n}\n",
       "arguments": [
         {
           "type": "String",
@@ -201,7 +201,7 @@
         }
       ],
       "network": "testnet",
-      "hash": "2a519aca1c9ca4568a30c893bd97580ee754f70cad65d2d2dd10abbfa31168ee"
+      "hash": "824aceed5812ff9f2d800eacf92d95789d1b54e5dfb17cb521cee43a7b71a571"
     },
     {
       "id": "TH.19",

--- a/lib/go/templates/manifest/manifest.go
+++ b/lib/go/templates/manifest/manifest.go
@@ -233,7 +233,7 @@ func generateManifest(env templates.Environment) *manifest {
 	m.addTemplate(generateTemplate(
 		"TH.17", "Register Delegator",
 		env,
-		templates.GenerateRegisterDelegatorScript,
+		templates.GenerateCreateLockedDelegatorScript,
 		[]argument{
 			{
 				Type:  "String",


### PR DESCRIPTION
I mistakenly used the _unlocked_ FLOW "register delegator" transaction rather than the locked FLOW version when generating the transaction template manifests for the Ledger app. 🤦  This PR fixes the manifest files to use the expected transaction template.