### PR TITLE
script for getting the total balance of an account

### DIFF
--- a/lib/go/templates/lockedtokens_templates.go
+++ b/lib/go/templates/lockedtokens_templates.go
@@ -27,6 +27,7 @@ const (
 	getLockedAccountAddressFilename = "lockedTokens/user/get_locked_account_address.cdc"
 	getLockedAccountBalanceFilename = "lockedTokens/user/get_locked_account_balance.cdc"
 	getUnlockLimitFilename          = "lockedTokens/user/get_unlock_limit.cdc"
+	getTotalBalanceFilename         = "lockedTokens/user/get_total_balance.cdc"
 
 	// staker templates
 	registerLockedNodeFilename                 = "lockedTokens/staker/register_node.cdc"
@@ -157,6 +158,12 @@ func GenerateGetLockedAccountBalanceScript(env Environment) []byte {
 
 func GenerateGetUnlockLimitScript(env Environment) []byte {
 	code := assets.MustAssetString(getUnlockLimitFilename)
+
+	return []byte(replaceAddresses(code, env))
+}
+
+func GenerateGetTotalBalanceScript(env Environment) []byte {
+	code := assets.MustAssetString(getTotalBalanceFilename)
 
 	return []byte(replaceAddresses(code, env))
 }

--- a/transactions/lockedTokens/user/get_total_balance.cdc
+++ b/transactions/lockedTokens/user/get_total_balance.cdc
@@ -17,6 +17,29 @@ pub fun main(address: Address): UFix64 {
 
     sum = sum + vaultRef.balance
 
+    let nodeStakerCap = account
+        .getCapability<&{FlowIDTableStaking.NodeStakerPublic}>(
+            FlowIDTableStaking.NodeStakerPublicPath
+        )!
+
+    if let nodeStakerRef = nodeStakerCap.borrow() {
+        let nodeInfo = FlowIDTableStaking.NodeInfo(nodeID: nodeStakerRef.id)
+        sum = sum + nodeInfo.tokensStaked + nodeInfo.totalTokensStaked + nodeInfo.tokensCommitted + nodeInfo.tokensUnstaking + nodeInfo.tokensUnstaked + nodeInfo.tokensRewarded
+    }
+
+    let delegatorCap = account
+        .getCapability<&{FlowIDTableStaking.NodeDelegatorPublic}>(
+            /public/flowStakingDelegator
+        )!
+
+    if let delegatorRef = delegatorCap.borrow() {
+        let delegatorInfo = FlowIDTableStaking.DelegatorInfo(
+            nodeID: delegatorRef.nodeID,
+            delegatorID: delegatorRef.id
+        )
+        sum = sum + delegatorInfo.tokensStaked + delegatorInfo.tokensCommitted + delegatorInfo.tokensUnstaking + delegatorInfo.tokensUnstaked + delegatorInfo.tokensRewarded
+    }
+
     let lockedAccountInfoCap = account
         .getCapability<&LockedTokens.TokenHolder{LockedTokens.LockedAccountInfo}>(
             LockedTokens.LockedAccountInfoPublicPath

--- a/transactions/lockedTokens/user/get_total_balance.cdc
+++ b/transactions/lockedTokens/user/get_total_balance.cdc
@@ -1,0 +1,42 @@
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import FlowToken from 0xTOKENADDRESS
+import FlowIDTableStaking from 0xIDENTITYTABLEADDRESS
+import LockedTokens from 0xLOCKEDTOKENADDRESS
+
+
+pub fun main(address: Address): UFix64 {
+
+    var sum = 0.0
+
+    let account = getAccount(address)
+
+    let vaultRef = account
+        .getCapability(/public/flowTokenBalance)!
+        .borrow<&FlowToken.Vault{FungibleToken.Balance}>()
+        ?? panic("Could not borrow Balance reference to the Vault")
+
+    sum = sum + vaultRef.balance
+
+    let lockedAccountInfoCap = account
+        .getCapability<&LockedTokens.TokenHolder{LockedTokens.LockedAccountInfo}>(
+            LockedTokens.LockedAccountInfoPublicPath
+        )!
+
+    if let lockedAccountInfoRef = lockedAccountInfoCap.borrow() {
+        sum = sum + lockedAccountInfoRef.getLockedAccountBalance()
+
+        if let nodeID = lockedAccountInfoRef.getNodeID() {
+            let nodeInfo = FlowIDTableStaking.NodeInfo(nodeID: nodeID)
+            sum = sum + nodeInfo.tokensStaked + nodeInfo.totalTokensStaked + nodeInfo.tokensCommitted + nodeInfo.tokensUnstaking + nodeInfo.tokensUnstaked + nodeInfo.tokensRewarded
+        }
+
+        if let delegatorID = lockedAccountInfoRef.getDelegatorID() {
+            if let nodeID = lockedAccountInfoRef.getDelegatorNodeID() {
+                let delegatorInfo = FlowIDTableStaking.DelegatorInfo(nodeID: nodeID, delegatorID: delegatorID)
+                sum = sum + delegatorInfo.tokensStaked + delegatorInfo.tokensCommitted + delegatorInfo.tokensUnstaking + delegatorInfo.tokensUnstaked + delegatorInfo.tokensRewarded
+            }
+        }
+    }
+
+    return sum
+}


### PR DESCRIPTION
This script gets the TOTAL number of FLOW an account owns, across unlocked, locked, and staking.

Adds up these numbers:

* tokens in normal account
* tokens in normal account staking
* tokens in normal account delegating
* tokens in shared account
* tokens in shared account staking
* tokens in shared account delegating

To get the total number of FLOW across all accounts that an address controls.

This will not be able to include the staking or delegating balance of an **UNLOCKED** account who hasn't ran the transaction to add the public capability to their account to [get node info](https://github.com/onflow/flow-core-contracts/blob/master/transactions/idTableStaking/node_add_capability.cdc) or [delegator info](https://github.com/onflow/flow-core-contracts/pull/105)
This restriction only applies to a couple accounts, because 99% of accounts only stake with locked FLOW