### PR TITLE
script to return nodes in the approved list which are not currently staked

### DIFF
--- a/transactions/idTableStaking/scripts/get_approved_but_not_staked_nodes.cdc
+++ b/transactions/idTableStaking/scripts/get_approved_but_not_staked_nodes.cdc
@@ -1,0 +1,20 @@
+import FlowIDTableStaking from 0x8624b52f9ddcd04a
+
+// This script returns the list of nodes that are on the approved list but are not staked.
+pub fun main(): [String] {
+    let approvedIDs = FlowIDTableStaking.getApprovedList()
+    let stakedIDs = FlowIDTableStaking.getStakedNodeIDs()
+
+    let stakedIDsMap: {String: Bool} = {}
+	for stakedID in stakedIDs {
+		stakedIDsMap[stakedID] = true
+	}
+
+	let extraNodeIDs: [String] = []
+    for approvedID in approvedIDs {
+           if stakedIDsMap[approvedID] != true {
+			    extraNodeIDs.append(approvedID)
+            }
+    }
+    return extraNodeIDs
+}

--- a/transactions/idTableStaking/scripts/get_approved_but_not_staked_nodes.cdc
+++ b/transactions/idTableStaking/scripts/get_approved_but_not_staked_nodes.cdc
@@ -1,4 +1,4 @@
-import FlowIDTableStaking from 0x8624b52f9ddcd04a
+import FlowIDTableStaking from 0xIDENTITYTABLEADDRESS
 
 // This script returns the list of nodes that are on the approved list but are not staked.
 pub fun main(): [String] {


### PR DESCRIPTION
On mainnet this gives,

> $ flow scripts execute  ./transactions/idTableStaking/scripts/get_approved_but_not_staked_nodes.cdc -n mainnet
> 
> Result: ["1780288437c9aed5056836bfffcfe19334dd6e229607fccfb3fe9b1d4d24cdca", "237a7a04ecf88b7c21001589ecc277190a6f7cd6e56a296a203552ade6db0927", "5a4bff17941a73909472afe23f1ccdc59d7526f93b16b4e374bd8353f8b624b4", "94609410b05584616f628f98a26acec339f7e1ce43132f0d8d268540317023d8", "a67ca1afd47c58358c656dffa2e5585d80b01371866e5634b68dcbab090b9b6f", "da27c0fc2a4fe12c04bd70058252c5a26cfe41485bf6ea6aba1c724b7a07542d", "dc3054cae816874d7dbbe838a41ef97c8a01b44643bffc82afe3a8228eed29fd", "069d081eb931c30e73c8dfbbf6359198f48c9e650d3d25a7449267de811d4fca", "a1fd244595bcd4371f1abc38a60384b87b25a41e806ce970ec19ea6c651f365b", "dfe68dcea8dc6cd54b56899c8ebb1ae144edcd8f4527fe7572cf4125f4c5a7ac", "1059d479c9ce3d6fd9cc48fca99fc5135b59e7f944c3ab14aca56b054209bf20", "2c08e4113b88e3709e06de152b64127be20d1b2db7d6a5c018b85f131ae330b4", "8894e0d5092ad62c5498b71b4f0680f60ba3828ace7b3329a2aeb94f2a7242fb", "1fecd2813d2b931a7cc10efd5d0e53936e0dfb4e31d67750201c5e02dad0bdaf", "44b928d503a90afe50333314f8eac8dc2e3fa982bc49ba246e15bb6b0c494a31", "dd9fa94156de9a05d6f344eb83943418ad6436d25ee26695bd7610d4d90ebaa8", "864b8e7d8770a2342d02c251b0b5508d7795726605f9f6069237b5eb8eb1db29"]
