### PR TITLE
Retract incorrectly tagged out-of-order version (`v1.2.3`)

### DIFF
--- a/lib/go/contracts/go.mod
+++ b/lib/go/contracts/go.mod
@@ -44,6 +44,6 @@ require (
 // despite it being several months old and many revisions behind the tip.
 // This retract block is based on https://go.dev/ref/mod#go-mod-file-retract.
 retract (
-	v1.2.3 // accidentally published with out-of-order tag
 	v1.2.4 // contains retraction only
+	v1.2.3 // accidentally published with out-of-order tag
 )

--- a/lib/go/contracts/go.mod
+++ b/lib/go/contracts/go.mod
@@ -38,3 +38,12 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// This retraction block retracts version v1.2.3, which was tagged out-of-order.
+// Currently go considers v1.2.3 to be the latest version, due to semver ordering,
+// despite it being several months old and many revisions behind the tip.
+// This retract block is based on https://go.dev/ref/mod#go-mod-file-retract.
+retract (
+	v1.2.3 // accidentally published with out-of-order tag
+	v1.2.4 // contains retraction only
+)

--- a/lib/go/templates/go.mod
+++ b/lib/go/templates/go.mod
@@ -56,6 +56,6 @@ require (
 // despite it being several months old and many revisions behind the tip.
 // This retract block is based on https://go.dev/ref/mod#go-mod-file-retract.
 retract (
-	v1.2.3 // accidentally published with out-of-order tag
 	v1.2.4 // contains retraction only
+	v1.2.3 // accidentally published with out-of-order tag
 )

--- a/lib/go/templates/go.mod
+++ b/lib/go/templates/go.mod
@@ -50,3 +50,12 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// This retraction block retracts version v1.2.3, which was tagged out-of-order.
+// Currently go considers v1.2.3 to be the latest version, due to semver ordering,
+// despite it being several months old and many revisions behind the tip.
+// This retract block is based on https://go.dev/ref/mod#go-mod-file-retract.
+retract (
+	v1.2.3 // accidentally published with out-of-order tag
+	v1.2.4 // contains retraction only
+)


### PR DESCRIPTION
## Context

A few months ago an out-of-order semver tag was pushed (`v1.2.3`). The tag was removed from the repository, however, since it was depended on by another Go module before being removed, we also need to explicitly mark the version as retracted to fully correct the Go tooling's behaviour.

## Why is this a problem

- Requesting modules `@latest` will return version `v1.2.3` rather than the actual most recent version
- Upgrading modules (eg. `go get -u ...`) will "upgrade" the `core-contracts` modules to `v1.2.3`
- If a module and its dependencies require multiple different versions of a `core-contracts` module, one of which is `v1.2.3` (or any untagged commit after `v1.2.3`), then Go will build with `v1.2.3` rather than the actual most recent version

## How this fixes the problem

This PR marks the incorrectly tagged version as retracted, which means go tooling will no longer consider it the latest version (and won't attempt to automatically upgrade to it).

In addition, once this is merged, we will need to tag v1.2.4:
- this creates a new largest semver version, which go will consider as latest
- go tooling will download this v1.2.4 version, read the retract statements, then correctly interpret the true latest version to be v0.X.Y

This is needed because once a version is added to the sum.golang.org database, it is never removed (prioritizing build stability). See https://go.dev/ref/mod#checksum-database, which this change is based off, for more details.