### PR TITLE
Add Makefile target to generate code (only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 .PHONY: test
-test: 
-	$(MAKE) generate -C lib/go
+test: generate
 	$(MAKE) test -C lib/go
 	flow test --cover --covercode="contracts" tests/*.cdc
+
+.PHONY: generate
+generate:
+	$(MAKE) generate -C lib/go
 
 .PHONY: ci
 ci:


### PR DESCRIPTION
Previously the top-level codegen function was bundled with test running. This decouples it to a separate command. `make test` will still always re-generate code.