### PR TITLE
Adds CrossVMMetadataViews to templates package

### DIFF
--- a/lib/go/templates/templates.go
+++ b/lib/go/templates/templates.go
@@ -14,28 +14,29 @@ import (
 )
 
 const (
-	placeholderFungibleTokenAddress       = "\"FungibleToken\""
-	placeholderNonFungibleTokenAddress    = "\"NonFungibleToken\""
-	placeholderEVMAddress                 = "\"EVM\""
-	placeholderViewResolverAddress        = "\"ViewResolver\""
-	placeholderFungibleTokenMVAddress     = "\"FungibleTokenMetadataViews\""
-	placeholderMetadataViewsAddress       = "\"MetadataViews\""
-	placeholderBurnerAddress              = "\"Burner\""
-	placeholderCryptoAddress              = "\"Crypto\""
-	placeholderFlowTokenAddress           = "\"FlowToken\""
-	placeholderIDTableAddress             = "\"FlowIDTableStaking\""
-	placeholderLockedTokensAddress        = "\"LockedTokens\""
-	placeholderStakingProxyAddress        = "\"StakingProxy\""
-	placeholderQuorumCertificateAddress   = "\"FlowClusterQC\""
-	placeholderFlowFeesAddress            = "\"FlowFees\""
-	placeholderStorageFeesAddress         = "\"FlowStorageFees\""
-	placeholderExecutionParametersAddress = "\"FlowExecutionParameters\""
-	placeholderServiceAccountAddress      = "\"FlowServiceAccount\""
-	placeholderDKGAddress                 = "\"FlowDKG\""
-	placeholderEpochAddress               = "\"FlowEpoch\""
-	placeholderStakingCollectionAddress   = "\"FlowStakingCollection\""
-	placeholderNodeVersionBeaconAddress   = "\"NodeVersionBeacon\""
-	placeholderRandomBeaconHistoryAddress = "\"RandomBeaconHistory\""
+	placeholderFungibleTokenAddress        = "\"FungibleToken\""
+	placeholderNonFungibleTokenAddress     = "\"NonFungibleToken\""
+	placeholderEVMAddress                  = "\"EVM\""
+	placeholderViewResolverAddress         = "\"ViewResolver\""
+	placeholderFungibleTokenMVAddress      = "\"FungibleTokenMetadataViews\""
+	placeholderMetadataViewsAddress        = "\"MetadataViews\""
+	placeholderCrossVMMetadataViewsAddress = "\"CrossVMMetadataViews\""
+	placeholderBurnerAddress               = "\"Burner\""
+	placeholderCryptoAddress               = "\"Crypto\""
+	placeholderFlowTokenAddress            = "\"FlowToken\""
+	placeholderIDTableAddress              = "\"FlowIDTableStaking\""
+	placeholderLockedTokensAddress         = "\"LockedTokens\""
+	placeholderStakingProxyAddress         = "\"StakingProxy\""
+	placeholderQuorumCertificateAddress    = "\"FlowClusterQC\""
+	placeholderFlowFeesAddress             = "\"FlowFees\""
+	placeholderStorageFeesAddress          = "\"FlowStorageFees\""
+	placeholderExecutionParametersAddress  = "\"FlowExecutionParameters\""
+	placeholderServiceAccountAddress       = "\"FlowServiceAccount\""
+	placeholderDKGAddress                  = "\"FlowDKG\""
+	placeholderEpochAddress                = "\"FlowEpoch\""
+	placeholderStakingCollectionAddress    = "\"FlowStakingCollection\""
+	placeholderNodeVersionBeaconAddress    = "\"NodeVersionBeacon\""
+	placeholderRandomBeaconHistoryAddress  = "\"RandomBeaconHistory\""
 )
 
 type Environment struct {
@@ -47,6 +48,7 @@ type Environment struct {
 	NonFungibleTokenAddress           string
 	EVMAddress                        string
 	MetadataViewsAddress              string
+	CrossVMMetadataViewsAddress       string
 	FungibleTokenMetadataViewsAddress string
 	FungibleTokenSwitchboardAddress   string
 	FlowTokenAddress                  string
@@ -110,6 +112,12 @@ func ReplaceAddresses(code string, env Environment) string {
 		code,
 		placeholderMetadataViewsAddress,
 		env.MetadataViewsAddress,
+	)
+
+	code = ReplaceAddress(
+		code,
+		placeholderCrossVMMetadataViewsAddress,
+		env.CrossVMMetadataViewsAddress,
 	)
 
 	code = ReplaceAddress(


### PR DESCRIPTION
Adds the `CrossVMMetadataViews` placeholders, address, and replacement to the templates package so that it can be used properly in flow-go and other places for bootstrapping and testing