### PR TITLE
Return transaction id from callback manager schedule function

### DIFF
--- a/contracts/FlowTransactionSchedulerUtils.cdc
+++ b/contracts/FlowTransactionSchedulerUtils.cdc
@@ -37,7 +37,7 @@ access(all) contract FlowTransactionSchedulerUtils {
             priority: FlowTransactionScheduler.Priority,
             executionEffort: UInt64,
             fees: @FlowToken.Vault
-        ) {
+        ): UInt64 {
             // Clean up any invalid transactions before scheduling a new one
             self.cleanup()
 
@@ -51,8 +51,12 @@ access(all) contract FlowTransactionSchedulerUtils {
                 fees: <-fees
             )
 
+            // Save transaction id to return it to the user later
+            let transactionId = scheduledTransaction.id
             // Store the transaction in our dictionary
-            self.scheduledTransactions[scheduledTransaction.id] <-! scheduledTransaction
+            self.scheduledTransactions[transactionId] <-! scheduledTransaction
+
+            return transactionId
         }
 
         /// Cancel a scheduled transaction by its ID


### PR DESCRIPTION
Add transaction id as return value when scheduling through the Manager.

This could be a great benefit to be able to get a direct reference to what we just scheduled so that it can be used for further operations in the same transaction if needed or stored somewhere after scheduling. Moreover is backward compatible and a minimal change.