### PR TITLE
Adds FlowTransactionSchedulerUtils contract

### DIFF
--- a/contracts/FlowTransactionScheduler.cdc
+++ b/contracts/FlowTransactionScheduler.cdc
@@ -276,6 +276,14 @@ access(all) contract FlowTransactionScheduler {
         access(contract) view fun getData(): AnyStruct? {
             return self.data
         }
+
+        /// getUnentitledHandlerReference returns an un-entitled reference to the transaction handler
+        /// This allows users to query metadata views about the handler
+        /// @return: An un-entitled reference to the transaction handler
+        access(all) view fun getUnentitledHandlerReference(): &{TransactionHandler} {
+            return self.handler.borrow() as? &{TransactionHandler}
+                ?? panic("Invalid transaction handler: Could not borrow a reference to the transaction handler")
+        }
     }
 
     /// Struct interface representing all the base configuration details in the Scheduler contract

--- a/contracts/FlowTransactionSchedulerUtils.cdc
+++ b/contracts/FlowTransactionSchedulerUtils.cdc
@@ -43,6 +43,28 @@ access(all) contract FlowTransactionSchedulerUtils {
             self.handlers = {}
         }
 
+        /// scheduleByHandler schedules a transaction by a given handler that has been used before
+        /// @param handlerTypeIdentifier: The type identifier of the handler
+        /// @param data: Optional data to pass to the transaction when executed
+        /// @param timestamp: The timestamp when the transaction should be executed
+        /// @param priority: The priority of the transaction (High, Medium, or Low)
+        /// @param executionEffort: The execution effort for the transaction
+        /// @param fees: A FlowToken vault containing sufficient fees
+        /// @return: The ID of the scheduled transaction
+        access(Owner) fun scheduleByHandler(
+            handlerTypeIdentifier: String,
+            data: AnyStruct?,
+            timestamp: UFix64,
+            priority: FlowTransactionScheduler.Priority,
+            executionEffort: UInt64,
+            fees: @FlowToken.Vault
+        ): UInt64 {
+            pre {
+                self.handlers.containsKey(handlerTypeIdentifier): "Invalid handler type identifier: Handler with type identifier \(handlerTypeIdentifier) not found in manager"
+            }
+            return self.schedule(handlerCap: self.handlers[handlerTypeIdentifier]!, data: data, timestamp: timestamp, priority: priority, executionEffort: executionEffort, fees: <-fees)
+        }
+
         /// Schedule a transaction and store it in the manager's dictionary
         /// @param handlerCap: A capability to a resource that implements the TransactionHandler interface
         /// @param data: Optional data to pass to the transaction when executed
@@ -50,7 +72,7 @@ access(all) contract FlowTransactionSchedulerUtils {
         /// @param priority: The priority of the transaction (High, Medium, or Low)
         /// @param executionEffort: The execution effort for the transaction
         /// @param fees: A FlowToken vault containing sufficient fees
-        /// @return: The scheduled transaction resource
+        /// @return: The ID of the scheduled transaction
         access(Owner) fun schedule(
             handlerCap: Capability<auth(FlowTransactionScheduler.Execute) &{FlowTransactionScheduler.TransactionHandler}>,
             data: AnyStruct?,
@@ -293,16 +315,16 @@ access(all) contract FlowTransactionSchedulerUtils {
         access(all) let description: String
 
         // path where this handler should be stored in storage
-        access(all) let storagePath: String
+        access(all) let storagePath: StoragePath
 
         // path where this handler's public capability should be found
-        access(all) let publicPath: String
+        access(all) let publicPath: PublicPath
 
         init(
             name: String,
             description: String,
-            storagePath: String,
-            publicPath: String
+            storagePath: StoragePath,
+            publicPath: PublicPath
         ) {
             self.name = name
             self.description = description

--- a/contracts/FlowTransactionSchedulerUtils.cdc
+++ b/contracts/FlowTransactionSchedulerUtils.cdc
@@ -1,0 +1,313 @@
+import "FlowTransactionScheduler"
+import "FlowToken"
+
+access(all) contract FlowTransactionSchedulerUtils {
+
+    /// Storage path for Manager resources
+    access(all) let managerStoragePath: StoragePath
+
+    /// Public path for Manager resources
+    access(all) let managerPublicPath: PublicPath
+
+    /// Entitlements
+    access(all) entitlement Owner
+
+    /// Manager resource is meant to provide users and developers with a simple way
+    /// to group the scheduled transactions that they own into one place to make it more
+    /// convenient to schedule/cancel transactions and get information about the transactions
+    /// that are managed.
+    /// It stores ScheduledTransaction resources in a dictionary and has other fields
+    /// to track the scheduled transactions by timestamp and handler
+    ///
+    access(all) resource Manager {
+        /// Dictionary storing scheduled transactions by their ID
+        access(self) var scheduledTransactions: @{UInt64: FlowTransactionScheduler.ScheduledTransaction}
+
+        /// Sorted array of timestamps that this manager has transactions scheduled at
+        access(self) var sortedTimestamps: FlowTransactionScheduler.SortedTimestamps
+
+        /// Dictionary storing the IDs of the transactions scheduled at a given timestamp
+        access(self) let idsByTimestamp: {UFix64: [UInt64]}
+
+        /// Dictionary storing the IDs of the transactions scheduled using a given handler
+        access(self) let idsByHandler: {String: [UInt64]}
+
+        /// Dictionary storing the handlers that this manager has scheduled transactions for at one point
+        access(self) let handlers: {String: Capability<auth(FlowTransactionScheduler.Execute) &{FlowTransactionScheduler.TransactionHandler}>}
+
+        init() {
+            self.scheduledTransactions <- {}
+            self.sortedTimestamps = FlowTransactionScheduler.SortedTimestamps()
+            self.idsByTimestamp = {}
+            self.idsByHandler = {}
+            self.handlers = {}
+        }
+
+        /// Schedule a transaction and store it in the manager's dictionary
+        /// @param handlerCap: A capability to a resource that implements the TransactionHandler interface
+        /// @param data: Optional data to pass to the transaction when executed
+        /// @param timestamp: The timestamp when the transaction should be executed
+        /// @param priority: The priority of the transaction (High, Medium, or Low)
+        /// @param executionEffort: The execution effort for the transaction
+        /// @param fees: A FlowToken vault containing sufficient fees
+        /// @return: The scheduled transaction resource
+        access(Owner) fun schedule(
+            handlerCap: Capability<auth(FlowTransactionScheduler.Execute) &{FlowTransactionScheduler.TransactionHandler}>,
+            data: AnyStruct?,
+            timestamp: UFix64,
+            priority: FlowTransactionScheduler.Priority,
+            executionEffort: UInt64,
+            fees: @FlowToken.Vault
+        ): UInt64 {
+            // Clean up any stale transactions before scheduling a new one
+            self.cleanup()
+
+            // Route to the main FlowTransactionScheduler
+            let scheduledTransaction <- FlowTransactionScheduler.schedule(
+                handlerCap: handlerCap,
+                data: data,
+                timestamp: timestamp,
+                priority: priority,
+                executionEffort: executionEffort,
+                fees: <-fees
+            )
+
+            let id = scheduledTransaction.id
+            let handlerRef = handlerCap.borrow()
+                ?? panic("Invalid transaction handler: Could not borrow a reference to the transaction handler")
+            let handlerTypeIdentifier = handlerRef.getType().identifier
+
+            self.handlers[handlerTypeIdentifier] = handlerCap
+
+            // Store the transaction in our dictionary
+            self.scheduledTransactions[scheduledTransaction.id] <-! scheduledTransaction
+
+            self.sortedTimestamps.add(timestamp: timestamp)
+
+            if let ids = self.idsByTimestamp[timestamp] {
+                ids.append(id)
+                self.idsByTimestamp[timestamp] = ids
+            } else {
+                self.idsByTimestamp[timestamp] = [id]
+            }
+
+            if let ids = self.idsByHandler[handlerTypeIdentifier] {
+                ids.append(id)
+                self.idsByHandler[handlerTypeIdentifier] = ids
+            } else {
+                self.idsByHandler[handlerTypeIdentifier] = [id]
+            }
+
+            return id
+        }
+
+        /// Cancel a scheduled transaction by its ID
+        /// @param id: The ID of the transaction to cancel
+        /// @return: A FlowToken vault containing the refunded fees
+        access(Owner) fun cancel(id: UInt64): @FlowToken.Vault {
+            // Remove the transaction from our dictionary
+            let tx <- self.scheduledTransactions.remove(key: id)
+                ?? panic("Invalid ID: Transaction with ID \(id) not found in manager")
+
+            let transactionData = FlowTransactionScheduler.getTransactionData(id: id)
+                ?? panic("Invalid ID: Transaction with ID \(id) not found in scheduler")
+
+            self.removeID(id: id, timestamp: tx.timestamp, handlerTypeIdentifier: tx.handlerTypeIdentifier)
+
+            // Cancel the transaction through the main scheduler
+            let refundedFees <- FlowTransactionScheduler.cancel(scheduledTx: <-tx!)
+
+            return <-refundedFees
+        }
+
+        /// Remove an ID from the manager's fields
+        /// @param id: The ID of the transaction to remove
+        /// @param timestamp: The timestamp of the transaction to remove
+        /// @param handlerTypeIdentifier: The type identifier of the handler of the transaction to remove
+        access(self) fun removeID(id: UInt64, timestamp: UFix64, handlerTypeIdentifier: String) {
+            if let ids = self.idsByTimestamp[timestamp] {
+                let index = ids.firstIndex(of: id)
+                ids.remove(at: index!)
+                if ids.length == 0 {
+                    self.idsByTimestamp.remove(key: timestamp)
+                } else {
+                    self.idsByTimestamp[timestamp] = ids
+                }
+            }
+
+            if let ids = self.idsByHandler[handlerTypeIdentifier] {
+                let index = ids.firstIndex(of: id)
+                ids.remove(at: index!)
+                self.idsByHandler[handlerTypeIdentifier] = ids
+            }
+        }
+
+        /// Clean up transactions that are no longer valid (return nil or Unknown status)
+        /// This removes and destroys transactions that have been executed, canceled, or are otherwise invalid
+        /// @return: The transactions that were cleaned up (removed from the manager)
+        access(Owner) fun cleanup(): [UInt64] {
+            let currentTimestamp = getCurrentBlock().timestamp
+            var transactionsToRemove: [UInt64] = []
+
+            let pastTimestamps = self.sortedTimestamps.getBefore(current: currentTimestamp)
+            for timestamp in pastTimestamps {
+                let ids = self.idsByTimestamp[timestamp] ?? []
+                for id in ids {
+                    let status = FlowTransactionScheduler.getStatus(id: id)
+                    if status == nil || status == FlowTransactionScheduler.Status.Unknown {
+                        transactionsToRemove.append(id)
+                    }
+                }
+            }
+
+            // Then remove and destroy the identified transactions
+            for id in transactionsToRemove {
+                if let tx <- self.scheduledTransactions.remove(key: id) {
+                    self.removeID(id: id, timestamp: tx.timestamp, handlerTypeIdentifier: tx.handlerTypeIdentifier)
+                    destroy tx
+                }
+            }
+
+            return transactionsToRemove
+        }
+
+        /// Get transaction data by its ID
+        /// @param id: The ID of the transaction to retrieve
+        /// @return: The transaction data from FlowTransactionScheduler, or nil if not found
+        access(all) view fun getTransactionData(id: UInt64): FlowTransactionScheduler.TransactionData? {
+            if self.scheduledTransactions.containsKey(id) {
+                return FlowTransactionScheduler.getTransactionData(id: id)
+            }
+            return nil
+        }
+
+        /// Get an un-entitled reference to a transaction handler of a given ID
+        /// @param id: The ID of the transaction to retrieve
+        /// @return: A reference to the transaction handler, or nil if not found
+        access(all) view fun getTransactionHandler(id: UInt64): &{FlowTransactionScheduler.TransactionHandler}? {
+            let txData = self.getTransactionData(id: id)
+            return txData?.getUnentitledHandlerReference()
+        }
+
+        /// Get all the handler type identifiers that the manager has transactions scheduled for
+        /// @return: An array of all handler type identifiers
+        access(all) view fun getHandlerTypeIdentifiers(): [String] {
+            return self.handlers.keys
+        }
+
+        /// Get all transaction IDs stored in the manager
+        /// @return: An array of all transaction IDs
+        access(all) view fun getTransactionIDs(): [UInt64] {
+            return self.scheduledTransactions.keys
+        }
+
+        /// Get all transaction IDs stored in the manager by a given handler
+        /// @param handlerTypeIdentifier: The type identifier of the handler
+        /// @return: An array of all transaction IDs
+        access(all) view fun getTransactionIDsByHandler(handlerTypeIdentifier: String): [UInt64] {
+            return self.idsByHandler[handlerTypeIdentifier] ?? []
+        }
+
+        /// Get all transaction IDs stored in the manager by a given timestamp
+        /// @param timestamp: The timestamp
+        /// @return: An array of all transaction IDs
+        access(all) view fun getTransactionIDsByTimestamp(timestamp: UFix64): [UInt64] {
+            return self.idsByTimestamp[timestamp] ?? []
+        }
+
+        /// Get all the timestamps and IDs from a given range of timestamps
+        /// @param startTimestamp: The start timestamp
+        /// @param endTimestamp: The end timestamp
+        /// @return: A dictionary of timestamps and IDs
+        access(all) fun getTransactionIDsByTimestampRange(startTimestamp: UFix64, endTimestamp: UFix64): {UFix64: [UInt64]} {
+            var transactionsInTimeframe: {UFix64: [UInt64]} = {}
+            
+            // Validate input parameters
+            if startTimestamp > endTimestamp {
+                return transactionsInTimeframe
+            }
+            
+            // Get all timestamps that fall within the specified range
+            let allTimestampsBeforeEnd = self.sortedTimestamps.getBefore(current: endTimestamp)
+            
+            for timestamp in allTimestampsBeforeEnd {
+                // Check if this timestamp falls within our range
+                if timestamp < startTimestamp { continue }
+                
+                var timestampTransactions: [UInt64] = self.idsByTimestamp[timestamp] ?? []
+                
+                if timestampTransactions.length > 0 {
+                    transactionsInTimeframe[timestamp] = timestampTransactions
+                }
+            }
+            
+            return transactionsInTimeframe
+        }
+
+        /// Get the status of a transaction by its ID
+        /// @param id: The ID of the transaction
+        /// @return: The status of the transaction, or Status.Unknown if not found in manager
+        access(all) view fun getTransactionStatus(id: UInt64): FlowTransactionScheduler.Status? {
+            if self.scheduledTransactions.containsKey(id) {
+                return FlowTransactionScheduler.getStatus(id: id)
+            }
+            return FlowTransactionScheduler.Status.Unknown
+        }
+    }
+
+    /// Create a new Manager instance
+    /// @return: A new Manager resource
+    access(all) fun createManager(): @Manager {
+        return <-create Manager()
+    }
+
+    access(all) init() {
+        self.managerStoragePath = /storage/flowTransactionSchedulerManager
+        self.managerPublicPath = /public/flowTransactionSchedulerManager
+    }
+
+    /// Get a public reference to a manager at the given address
+    /// @param address: The address of the manager
+    /// @return: A public reference to the manager
+    access(all) view fun getManager(address: Address): &Manager? {
+        return getAccount(address).capabilities.borrow<&Manager>(self.managerPublicPath)
+    }
+
+    /********************************************
+    
+    Scheduled Transactions Metadata Views
+    
+    ***********************************************/
+
+    /// HandlerData is a struct that contains the important data for a handler
+    /// that is used to identify the handler and its capabilities
+    /// The scheduled transactions smart contract will use this data to identify the handler
+    /// and its capabilities when scheduling a transaction and executing the transaction
+    /// The information from this view will be used in the events so it is very important that it is accurate
+    access(all) struct HandlerData {
+
+        // short name of the handler
+        access(all) let name: String
+
+        // description of what the handler does
+        access(all) let description: String
+
+        // path where this handler should be stored in storage
+        access(all) let storagePath: String
+
+        // path where this handler's public capability should be found
+        access(all) let publicPath: String
+
+        init(
+            name: String,
+            description: String,
+            storagePath: String,
+            publicPath: String
+        ) {
+            self.name = name
+            self.description = description
+            self.storagePath = storagePath
+            self.publicPath = publicPath
+        }
+    }
+}

--- a/contracts/testContracts/TestFlowScheduledTransactionHandler.cdc
+++ b/contracts/testContracts/TestFlowScheduledTransactionHandler.cdc
@@ -2,6 +2,7 @@ import "FlowTransactionScheduler"
 import "FlowTransactionSchedulerUtils"
 import "FlowToken"
 import "FungibleToken"
+import "MetadataViews"
 
 // ⚠️  WARNING: UNSAFE FOR PRODUCTION ⚠️
 // This is a TEST CONTRACT ONLY and should NEVER be used in production!
@@ -29,17 +30,29 @@ access(all) contract TestFlowScheduledTransactionHandler {
         }
 
         access(all) view fun getViews(): [Type] {
-            return [Type<FlowTransactionSchedulerUtils.HandlerData>()]
+            return [Type<StoragePath>(), Type<PublicPath>(), Type<FlowTransactionSchedulerUtils.HandlerData>()]
         }
 
         access(all) fun resolveView(_ view: Type): AnyStruct? {
             switch view {
+                case Type<StoragePath>():
+                    return TestFlowScheduledTransactionHandler.HandlerStoragePath
+                case Type<PublicPath>():
+                    return TestFlowScheduledTransactionHandler.HandlerPublicPath
+                case Type<MetadataViews.Display>():
+                    return MetadataViews.Display(
+                        name: self.name,
+                        description: self.description,
+                        thumbnail: MetadataViews.HTTPFile(
+                            url: ""
+                        )
+                    )
                 case Type<FlowTransactionSchedulerUtils.HandlerData>():
                     return FlowTransactionSchedulerUtils.HandlerData(
                         name: self.name,
                         description: self.description,
-                        storagePath: TestFlowScheduledTransactionHandler.HandlerStoragePath.toString(),
-                        publicPath: TestFlowScheduledTransactionHandler.HandlerPublicPath.toString()
+                        storagePath: TestFlowScheduledTransactionHandler.HandlerStoragePath,
+                        publicPath: TestFlowScheduledTransactionHandler.HandlerPublicPath
                     )
                 default:
                     return nil

--- a/flow.json
+++ b/flow.json
@@ -15,6 +15,13 @@
 				"testing": "0000000000000001"
 			}
 		},
+		"FlowTransactionSchedulerUtils": {
+			"source": "./contracts/FlowTransactionSchedulerUtils.cdc",
+			"aliases": {
+				"emulator": "f8d6e0586b0a20c7",
+				"testing": "0000000000000001"
+			}
+		},
 		"FlowClusterQC": {
 			"source": "./contracts/epochs/FlowClusterQC.cdc",
 			"aliases": {

--- a/lib/go/contracts/contracts.go
+++ b/lib/go/contracts/contracts.go
@@ -27,24 +27,25 @@ import (
 ///
 
 const (
-	flowFeesFilename                   = "FlowFees.cdc"
-	storageFeesFilename                = "FlowStorageFees.cdc"
-	executionParametersFilename        = "FlowExecutionParameters.cdc"
-	flowServiceAccountFilename         = "FlowServiceAccount.cdc"
-	flowTokenFilename                  = "FlowToken.cdc"
-	flowIdentityTableFilename          = "FlowIDTableStaking.cdc"
-	flowQCFilename                     = "epochs/FlowClusterQC.cdc"
-	flowDKGFilename                    = "epochs/FlowDKG.cdc"
-	flowEpochFilename                  = "epochs/FlowEpoch.cdc"
-	flowLockedTokensFilename           = "LockedTokens.cdc"
-	flowStakingProxyFilename           = "StakingProxy.cdc"
-	flowStakingCollectionFilename      = "FlowStakingCollection.cdc"
-	flowContractAuditsFilename         = "FlowContractAudits.cdc"
-	flowNodeVersionBeaconFilename      = "NodeVersionBeacon.cdc"
-	flowRandomBeaconHistoryFilename    = "RandomBeaconHistory.cdc"
-	cryptoFilename                     = "Crypto.cdc"
-	linearCodeAddressGeneratorFilename = "LinearCodeAddressGenerator.cdc"
-	flowTransactionSchedulerFilename   = "FlowTransactionScheduler.cdc"
+	flowFeesFilename                      = "FlowFees.cdc"
+	storageFeesFilename                   = "FlowStorageFees.cdc"
+	executionParametersFilename           = "FlowExecutionParameters.cdc"
+	flowServiceAccountFilename            = "FlowServiceAccount.cdc"
+	flowTokenFilename                     = "FlowToken.cdc"
+	flowIdentityTableFilename             = "FlowIDTableStaking.cdc"
+	flowQCFilename                        = "epochs/FlowClusterQC.cdc"
+	flowDKGFilename                       = "epochs/FlowDKG.cdc"
+	flowEpochFilename                     = "epochs/FlowEpoch.cdc"
+	flowLockedTokensFilename              = "LockedTokens.cdc"
+	flowStakingProxyFilename              = "StakingProxy.cdc"
+	flowStakingCollectionFilename         = "FlowStakingCollection.cdc"
+	flowContractAuditsFilename            = "FlowContractAudits.cdc"
+	flowNodeVersionBeaconFilename         = "NodeVersionBeacon.cdc"
+	flowRandomBeaconHistoryFilename       = "RandomBeaconHistory.cdc"
+	cryptoFilename                        = "Crypto.cdc"
+	linearCodeAddressGeneratorFilename    = "LinearCodeAddressGenerator.cdc"
+	flowTransactionSchedulerFilename      = "FlowTransactionScheduler.cdc"
+	flowTransactionSchedulerUtilsFilename = "FlowTransactionSchedulerUtils.cdc"
 
 	// Test contracts
 	// only used for testing
@@ -53,22 +54,23 @@ const (
 
 	// Each contract has placeholder addresses that need to be replaced
 	// depending on which network they are being used with
-	placeholderFungibleTokenAddress            = "\"FungibleToken\""
-	placeholderFungibleTokenMVAddress          = "\"FungibleTokenMetadataViews\""
-	placeholderMetadataViewsAddress            = "\"MetadataViews\""
-	placeholderFlowTokenAddress                = "\"FlowToken\""
-	placeholderIDTableAddress                  = "\"FlowIDTableStaking\""
-	placeholderBurnerAddress                   = "\"Burner\""
-	placeholderStakingProxyAddress             = "\"StakingProxy\""
-	placeholderQCAddr                          = "\"FlowClusterQC\""
-	placeholderDKGAddr                         = "\"FlowDKG\""
-	placeholderEpochAddr                       = "\"FlowEpoch\""
-	placeholderFlowFeesAddress                 = "\"FlowFees\""
-	placeholderStorageFeesAddress              = "\"FlowStorageFees\""
-	placeholderLockedTokensAddress             = "\"LockedTokens\""
-	placeholderStakingCollectionAddress        = "\"FlowStakingCollection\""
-	placeholderNodeVersionBeaconAddress        = "\"NodeVersionBeacon\""
-	placeholderFlowTransactionSchedulerAddress = "\"FlowTransactionScheduler\""
+	placeholderFungibleTokenAddress                 = "\"FungibleToken\""
+	placeholderFungibleTokenMVAddress               = "\"FungibleTokenMetadataViews\""
+	placeholderMetadataViewsAddress                 = "\"MetadataViews\""
+	placeholderFlowTokenAddress                     = "\"FlowToken\""
+	placeholderIDTableAddress                       = "\"FlowIDTableStaking\""
+	placeholderBurnerAddress                        = "\"Burner\""
+	placeholderStakingProxyAddress                  = "\"StakingProxy\""
+	placeholderQCAddr                               = "\"FlowClusterQC\""
+	placeholderDKGAddr                              = "\"FlowDKG\""
+	placeholderEpochAddr                            = "\"FlowEpoch\""
+	placeholderFlowFeesAddress                      = "\"FlowFees\""
+	placeholderStorageFeesAddress                   = "\"FlowStorageFees\""
+	placeholderLockedTokensAddress                  = "\"LockedTokens\""
+	placeholderStakingCollectionAddress             = "\"FlowStakingCollection\""
+	placeholderNodeVersionBeaconAddress             = "\"NodeVersionBeacon\""
+	placeholderFlowTransactionSchedulerAddress      = "\"FlowTransactionScheduler\""
+	placeholderFlowTransactionSchedulerUtilsAddress = "\"FlowTransactionSchedulerUtils\""
 )
 
 // Adds a `0x` prefix to the provided address string
@@ -299,6 +301,15 @@ func RandomBeaconHistory() []byte {
 // FlowTransactionScheduler returns the FlowTransactionScheduler contract.
 func FlowTransactionScheduler(env templates.Environment) []byte {
 	code := assets.MustAssetString(flowTransactionSchedulerFilename)
+
+	code = templates.ReplaceAddresses(code, env)
+
+	return []byte(code)
+}
+
+// FlowTransactionSchedulerUtils returns the FlowTransactionSchedulerUtils contract.
+func FlowTransactionSchedulerUtils(env templates.Environment) []byte {
+	code := assets.MustAssetString(flowTransactionSchedulerUtilsFilename)
 
 	code = templates.ReplaceAddresses(code, env)
 

--- a/lib/go/contracts/contracts_test.go
+++ b/lib/go/contracts/contracts_test.go
@@ -42,6 +42,7 @@ func SetAllAddresses(env *templates.Environment) {
 	env.NodeVersionBeaconAddress = fakeAddr
 	env.RandomBeaconHistoryAddress = fakeAddr
 	env.FlowTransactionSchedulerAddress = fakeAddr
+	env.FlowTransactionSchedulerUtilsAddress = fakeAddr
 }
 
 // Tests that a specific contract path should succeed when retrieving it
@@ -172,6 +173,15 @@ func TestFlowTransactionScheduler(t *testing.T) {
 	GetCadenceContractShouldSucceed(t, contract)
 	assert.Contains(t, contract, "import FlowToken from 0x")
 	assert.Contains(t, contract, "import FlowFees from 0x")
+}
+
+func TestFlowTransactionSchedulerUtils(t *testing.T) {
+	env := templates.Environment{}
+	SetAllAddresses(&env)
+	contract := string(contracts.FlowTransactionSchedulerUtils(env))
+	GetCadenceContractShouldSucceed(t, contract)
+	assert.Contains(t, contract, "import FlowToken from 0x")
+	assert.Contains(t, contract, "import FlowTransactionScheduler from 0x")
 }
 
 func TestFlowScheduledTransactionHandler(t *testing.T) {

--- a/lib/go/templates/templates.go
+++ b/lib/go/templates/templates.go
@@ -14,61 +14,63 @@ import (
 )
 
 const (
-	placeholderFungibleTokenAddress              = "\"FungibleToken\""
-	placeholderNonFungibleTokenAddress           = "\"NonFungibleToken\""
-	placeholderEVMAddress                        = "\"EVM\""
-	placeholderViewResolverAddress               = "\"ViewResolver\""
-	placeholderFungibleTokenMVAddress            = "\"FungibleTokenMetadataViews\""
-	placeholderMetadataViewsAddress              = "\"MetadataViews\""
-	placeholderCrossVMMetadataViewsAddress       = "\"CrossVMMetadataViews\""
-	placeholderBurnerAddress                     = "\"Burner\""
-	placeholderCryptoAddress                     = "\"Crypto\""
-	placeholderFlowTokenAddress                  = "\"FlowToken\""
-	placeholderIDTableAddress                    = "\"FlowIDTableStaking\""
-	placeholderLockedTokensAddress               = "\"LockedTokens\""
-	placeholderStakingProxyAddress               = "\"StakingProxy\""
-	placeholderQuorumCertificateAddress          = "\"FlowClusterQC\""
-	placeholderFlowFeesAddress                   = "\"FlowFees\""
-	placeholderStorageFeesAddress                = "\"FlowStorageFees\""
-	placeholderExecutionParametersAddress        = "\"FlowExecutionParameters\""
-	placeholderServiceAccountAddress             = "\"FlowServiceAccount\""
-	placeholderDKGAddress                        = "\"FlowDKG\""
-	placeholderEpochAddress                      = "\"FlowEpoch\""
-	placeholderStakingCollectionAddress          = "\"FlowStakingCollection\""
-	placeholderNodeVersionBeaconAddress          = "\"NodeVersionBeacon\""
-	placeholderRandomBeaconHistoryAddress        = "\"RandomBeaconHistory\""
-	placeholderLinearCodeAddressGeneratorAddress = "\"LinearCodeAddressGenerator\""
-	placeholderFlowTransactionSchedulerAddress   = "\"FlowTransactionScheduler\""
+	placeholderFungibleTokenAddress                 = "\"FungibleToken\""
+	placeholderNonFungibleTokenAddress              = "\"NonFungibleToken\""
+	placeholderEVMAddress                           = "\"EVM\""
+	placeholderViewResolverAddress                  = "\"ViewResolver\""
+	placeholderFungibleTokenMVAddress               = "\"FungibleTokenMetadataViews\""
+	placeholderMetadataViewsAddress                 = "\"MetadataViews\""
+	placeholderCrossVMMetadataViewsAddress          = "\"CrossVMMetadataViews\""
+	placeholderBurnerAddress                        = "\"Burner\""
+	placeholderCryptoAddress                        = "\"Crypto\""
+	placeholderFlowTokenAddress                     = "\"FlowToken\""
+	placeholderIDTableAddress                       = "\"FlowIDTableStaking\""
+	placeholderLockedTokensAddress                  = "\"LockedTokens\""
+	placeholderStakingProxyAddress                  = "\"StakingProxy\""
+	placeholderQuorumCertificateAddress             = "\"FlowClusterQC\""
+	placeholderFlowFeesAddress                      = "\"FlowFees\""
+	placeholderStorageFeesAddress                   = "\"FlowStorageFees\""
+	placeholderExecutionParametersAddress           = "\"FlowExecutionParameters\""
+	placeholderServiceAccountAddress                = "\"FlowServiceAccount\""
+	placeholderDKGAddress                           = "\"FlowDKG\""
+	placeholderEpochAddress                         = "\"FlowEpoch\""
+	placeholderStakingCollectionAddress             = "\"FlowStakingCollection\""
+	placeholderNodeVersionBeaconAddress             = "\"NodeVersionBeacon\""
+	placeholderRandomBeaconHistoryAddress           = "\"RandomBeaconHistory\""
+	placeholderLinearCodeAddressGeneratorAddress    = "\"LinearCodeAddressGenerator\""
+	placeholderFlowTransactionSchedulerAddress      = "\"FlowTransactionScheduler\""
+	placeholderFlowTransactionSchedulerUtilsAddress = "\"FlowTransactionSchedulerUtils\""
 )
 
 type Environment struct {
-	Network                           string
-	ViewResolverAddress               string
-	BurnerAddress                     string
-	CryptoAddress                     string
-	FungibleTokenAddress              string
-	NonFungibleTokenAddress           string
-	EVMAddress                        string
-	MetadataViewsAddress              string
-	CrossVMMetadataViewsAddress       string
-	FungibleTokenMetadataViewsAddress string
-	FungibleTokenSwitchboardAddress   string
-	FlowTokenAddress                  string
-	IDTableAddress                    string
-	LockedTokensAddress               string
-	StakingProxyAddress               string
-	QuorumCertificateAddress          string
-	DkgAddress                        string
-	EpochAddress                      string
-	StorageFeesAddress                string
-	FlowFeesAddress                   string
-	StakingCollectionAddress          string
-	FlowExecutionParametersAddress    string
-	ServiceAccountAddress             string
-	NodeVersionBeaconAddress          string
-	RandomBeaconHistoryAddress        string
-	LinearCodeAddressGeneratorAddress string
-	FlowTransactionSchedulerAddress   string
+	Network                              string
+	ViewResolverAddress                  string
+	BurnerAddress                        string
+	CryptoAddress                        string
+	FungibleTokenAddress                 string
+	NonFungibleTokenAddress              string
+	EVMAddress                           string
+	MetadataViewsAddress                 string
+	CrossVMMetadataViewsAddress          string
+	FungibleTokenMetadataViewsAddress    string
+	FungibleTokenSwitchboardAddress      string
+	FlowTokenAddress                     string
+	IDTableAddress                       string
+	LockedTokensAddress                  string
+	StakingProxyAddress                  string
+	QuorumCertificateAddress             string
+	DkgAddress                           string
+	EpochAddress                         string
+	StorageFeesAddress                   string
+	FlowFeesAddress                      string
+	StakingCollectionAddress             string
+	FlowExecutionParametersAddress       string
+	ServiceAccountAddress                string
+	NodeVersionBeaconAddress             string
+	RandomBeaconHistoryAddress           string
+	LinearCodeAddressGeneratorAddress    string
+	FlowTransactionSchedulerAddress      string
+	FlowTransactionSchedulerUtilsAddress string
 }
 
 func withHexPrefix(address string) string {
@@ -254,6 +256,12 @@ func ReplaceAddresses(code string, env Environment) string {
 		code,
 		placeholderFlowTransactionSchedulerAddress,
 		env.FlowTransactionSchedulerAddress,
+	)
+
+	code = ReplaceAddress(
+		code,
+		placeholderFlowTransactionSchedulerUtilsAddress,
+		env.FlowTransactionSchedulerUtilsAddress,
 	)
 
 	return code

--- a/tests/transactionScheduler_events_test.cdc
+++ b/tests/transactionScheduler_events_test.cdc
@@ -25,6 +25,13 @@ fun setup() {
     Test.expect(err, Test.beNil())
 
     err = Test.deployContract(
+        name: "FlowTransactionSchedulerUtils",
+        path: "../contracts/FlowTransactionSchedulerUtils.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+
+    err = Test.deployContract(
         name: "TestFlowScheduledTransactionHandler",
         path: "../contracts/testContracts/TestFlowScheduledTransactionHandler.cdc",
         arguments: []
@@ -72,14 +79,6 @@ access(all) fun testTransactionScheduleEventAndData() {
     
     let transactionID = scheduledEvent.id as UInt64
 
-    // Get scheduled transactions from test transaction handler
-    let scheduledTransactions = TestFlowScheduledTransactionHandler.scheduledTransactions.keys
-    Test.assert(scheduledTransactions.length == 1, message: "one scheduled transaction")
-    
-    let scheduled = TestFlowScheduledTransactionHandler.scheduledTransactions[scheduledTransactions[0]]!
-    Test.assert(scheduled.id == transactionID, message: "transaction ID mismatch")
-    Test.assert(scheduled.timestamp == timeInFuture, message: "incorrect timestamp")
-
     var status = getStatus(id: transactionID)
     Test.assertEqual(statusScheduled, status!)
 
@@ -126,7 +125,7 @@ access(all) fun testScheduledTransactionCancelationEvents() {
     // Cancel invalid transaction should fail
     cancelTransaction(
         id: 100,
-        failWithErr: "Invalid ID: 100 transaction not found"
+        failWithErr: "Invalid ID: Transaction with ID 100 not found in manager"
     )
 
     // Schedule a medium transaction
@@ -176,8 +175,6 @@ access(all) fun testScheduledTransactionExecution() {
     var timeInFuture = currentTime + futureDelta
 
     feesBalanceBefore = getFeesBalance()
-
-    var scheduledIDs = TestFlowScheduledTransactionHandler.scheduledTransactions.keys
 
     // Simulate FVM process - should not yet process since timestamp is in the future
     processTransactions()

--- a/tests/transactionScheduler_misc_test.cdc
+++ b/tests/transactionScheduler_misc_test.cdc
@@ -25,6 +25,13 @@ fun setup() {
     Test.expect(err, Test.beNil())
 
     err = Test.deployContract(
+        name: "FlowTransactionSchedulerUtils",
+        path: "../contracts/FlowTransactionSchedulerUtils.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+
+    err = Test.deployContract(
         name: "TestFlowScheduledTransactionHandler",
         path: "../contracts/testContracts/TestFlowScheduledTransactionHandler.cdc",
         arguments: []

--- a/tests/transactionScheduler_schedule_test.cdc
+++ b/tests/transactionScheduler_schedule_test.cdc
@@ -17,6 +17,13 @@ fun setup() {
     Test.expect(err, Test.beNil())
 
     err = Test.deployContract(
+        name: "FlowTransactionSchedulerUtils",
+        path: "../contracts/FlowTransactionSchedulerUtils.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+
+    err = Test.deployContract(
         name: "TestFlowScheduledTransactionHandler",
         path: "../contracts/testContracts/TestFlowScheduledTransactionHandler.cdc",
         arguments: []

--- a/tests/transactionScheduler_schedule_test.cdc
+++ b/tests/transactionScheduler_schedule_test.cdc
@@ -1013,7 +1013,7 @@ access(all) fun testScheduleAndEffortUsed() {
                 }
             },
             expectedPendingQueues: {
-                futureDelta: [1,3,4,5,6,7],
+                futureDelta: [2,3,4,5,6,7],
                 futureDelta + 1.0: [1,2,3,4,5,6,7]
             },
             expectedPendingQueueAfterExecution: []

--- a/tests/transactionScheduler_test.cdc
+++ b/tests/transactionScheduler_test.cdc
@@ -17,6 +17,13 @@ fun setup() {
     Test.expect(err, Test.beNil())
 
     err = Test.deployContract(
+        name: "FlowTransactionSchedulerUtils",
+        path: "../contracts/FlowTransactionSchedulerUtils.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+
+    err = Test.deployContract(
         name: "TestFlowScheduledTransactionHandler",
         path: "../contracts/testContracts/TestFlowScheduledTransactionHandler.cdc",
         arguments: []

--- a/transactions/transactionScheduler/cancel_transaction.cdc
+++ b/transactions/transactionScheduler/cancel_transaction.cdc
@@ -1,4 +1,5 @@
 import "FlowTransactionScheduler"
+import "FlowTransactionSchedulerUtils"
 import "TestFlowScheduledTransactionHandler"
 import "FlowToken"
 import "FungibleToken"
@@ -14,9 +15,12 @@ transaction(id: UInt64) {
 
     prepare(account: auth(BorrowValue, SaveValue, IssueStorageCapabilityController, PublishCapability, GetStorageCapabilityController) &Account) {
 
+        let manager = account.storage.borrow<auth(FlowTransactionSchedulerUtils.Owner) &FlowTransactionSchedulerUtils.Manager>(from: FlowTransactionSchedulerUtils.managerStoragePath)
+            ?? panic("Could not borrow a Manager reference from \(FlowTransactionSchedulerUtils.managerStoragePath)")
+
         let vault = account.storage.borrow<auth(FungibleToken.Withdraw) &FlowToken.Vault>(from: /storage/flowTokenVault)
             ?? panic("Could not borrow FlowToken vault")
 
-        vault.deposit(from: <-TestFlowScheduledTransactionHandler.cancelTransaction(id: id))
+        vault.deposit(from: <-manager.cancel(id: id))
     }
 } 

--- a/transactions/transactionScheduler/schedule_transaction.cdc
+++ b/transactions/transactionScheduler/schedule_transaction.cdc
@@ -1,4 +1,5 @@
 import "FlowTransactionScheduler"
+import "FlowTransactionSchedulerUtils"
 import "TestFlowScheduledTransactionHandler"
 import "FlowToken"
 import "FungibleToken"
@@ -22,6 +23,16 @@ import "FungibleToken"
 transaction(timestamp: UFix64, feeAmount: UFix64, effort: UInt64, priority: UInt8, testData: AnyStruct?) {
 
     prepare(account: auth(BorrowValue, SaveValue, IssueStorageCapabilityController, PublishCapability, GetStorageCapabilityController) &Account) {
+
+        // if a transaction scheduler manager has not been created for this account yet, create one
+        if !account.storage.check<@FlowTransactionSchedulerUtils.Manager>(from: FlowTransactionSchedulerUtils.managerStoragePath) {
+            let manager <- FlowTransactionSchedulerUtils.createManager()
+            account.storage.save(<-manager, to: FlowTransactionSchedulerUtils.managerStoragePath)
+
+            // create a public capability to the callback manager
+            let managerRef = account.capabilities.storage.issue<&FlowTransactionSchedulerUtils.Manager>(FlowTransactionSchedulerUtils.managerStoragePath)
+            account.capabilities.publish(managerRef, at: FlowTransactionSchedulerUtils.managerPublicPath)
+        }
         
         // If a transaction handler has not been created for this account yet, create one,
         // store it, and issue a capability that will be used to create the transaction
@@ -45,10 +56,14 @@ transaction(timestamp: UFix64, feeAmount: UFix64, effort: UInt64, priority: UInt
         let priorityEnum = FlowTransactionScheduler.Priority(rawValue: priority)
             ?? FlowTransactionScheduler.Priority.High
 
+        // borrow a reference to the callback manager
+        let manager = account.storage.borrow<auth(FlowTransactionSchedulerUtils.Owner) &FlowTransactionSchedulerUtils.Manager>(from: FlowTransactionSchedulerUtils.managerStoragePath)
+            ?? panic("Could not borrow a Manager reference from \(FlowTransactionSchedulerUtils.managerStoragePath)")
+
         if let dataString = testData as? String {
             if dataString == "schedule" {
                 // Schedule the transaction that schedules another transaction
-                let scheduledTransaction <- FlowTransactionScheduler.schedule(
+                manager.schedule(
                     handlerCap: handlerCap,
                     data: handlerCap,
                     timestamp: timestamp,
@@ -56,12 +71,11 @@ transaction(timestamp: UFix64, feeAmount: UFix64, effort: UInt64, priority: UInt
                     executionEffort: effort,
                     fees: <-fees
                 )
-                TestFlowScheduledTransactionHandler.addScheduledTransaction(scheduledTx: <-scheduledTransaction)
                 return
             }
         }
         // Schedule the regular transaction with the main contract
-        let scheduledTransaction <- FlowTransactionScheduler.schedule(
+        manager.schedule(
             handlerCap: handlerCap,
             data: testData,
             timestamp: timestamp,
@@ -69,6 +83,5 @@ transaction(timestamp: UFix64, feeAmount: UFix64, effort: UInt64, priority: UInt
             executionEffort: effort,
             fees: <-fees
         )
-        TestFlowScheduledTransactionHandler.addScheduledTransaction(scheduledTx: <-scheduledTransaction)
     }
 } 


### PR DESCRIPTION
Adds a contract that will contain utilities for the transaction scheduler contract
Currently it just has a scheduled transaction manager resource and a single metadata view, but we can add additional utility methods for reducing boilerplate in transactions and add additional resources for potentially managing handlers and other things.

This is nice from a developer education standpoint because it removes the unsafe patters we were using in the previous version with the public functions in the Handler contract and replaces them with the safer versions that use the manager resource.

