### PR TITLE
Mainnet Contract Upgrade Review: All 27 contracts

### DIFF
--- a/contracts/external/FlowEVMBridge.cdc
+++ b/contracts/external/FlowEVMBridge.cdc
@@ -1,0 +1,1194 @@
+import "Burner"
+import "FungibleToken"
+import "FungibleTokenMetadataViews"
+import "NonFungibleToken"
+import "MetadataViews"
+import "CrossVMMetadataViews"
+import "ViewResolver"
+
+import "EVM"
+
+import "IBridgePermissions"
+import "ICrossVM"
+import "IEVMBridgeNFTMinter"
+import "IEVMBridgeTokenMinter"
+import "IFlowEVMNFTBridge"
+import "IFlowEVMTokenBridge"
+import "CrossVMNFT"
+import "CrossVMToken"
+import "FlowEVMBridgeCustomAssociationTypes"
+import "FlowEVMBridgeCustomAssociations"
+import "FlowEVMBridgeConfig"
+import "FlowEVMBridgeHandlerInterfaces"
+import "FlowEVMBridgeUtils"
+import "FlowEVMBridgeNFTEscrow"
+import "FlowEVMBridgeTokenEscrow"
+import "FlowEVMBridgeTemplates"
+import "SerializeMetadata"
+
+/// The FlowEVMBridge contract is the main entrypoint for bridging NFT & FT assets between Flow & FlowEVM.
+///
+/// Before bridging, be sure to onboard the asset type which will configure the bridge to handle the asset. From there,
+/// the asset can be bridged between VMs via the COA as the entrypoint.
+///
+/// See also:
+/// - Code in context: https://github.com/onflow/flow-evm-bridge
+/// - FLIP #237: https://github.com/onflow/flips/pull/233
+///
+access(all)
+contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
+
+    /*************
+        Events
+    **************/
+
+    /// Emitted any time a new asset type is onboarded to the bridge
+    access(all)
+    event Onboarded(type: String, cadenceContractAddress: Address, evmContractAddress: String)
+    /// Denotes a defining contract was deployed to the bridge account
+    access(all)
+    event BridgeDefiningContractDeployed(
+        contractName: String,
+        assetName: String,
+        symbol: String,
+        isERC721: Bool,
+        evmContractAddress: String
+    )
+    /// Emitted whenever a bridged NFT is burned as a part of the bridging process. In the context of this contract,
+    /// this only occurs when an EVM-native ERC721 updates from a bridged NFT to their own custom Cadence NFT.
+    access(all)
+    event BridgedNFTBurned(type: String, id: UInt64, evmID: UInt256, uuid: UInt64, erc721Address: String)
+
+    /**************************
+        Public Onboarding
+    **************************/
+
+    /// Onboards a given asset by type to the bridge. Since we're onboarding by Cadence Type, the asset must be defined
+    /// in a third-party contract. Attempting to onboard a bridge-defined asset will result in an error as the asset has
+    /// already been onboarded to the bridge.
+    ///
+    /// @param type: The Cadence Type of the NFT to be onboarded
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    ///
+    access(all)
+    fun onboardByType(_ type: Type, feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}) {
+        pre {
+            !FlowEVMBridgeConfig.isPaused(): "Bridge operations are currently paused"
+            !FlowEVMBridgeConfig.isCadenceTypeBlocked(type):
+            "This Cadence Type \(type.identifier) is currently blocked from being onboarded"
+            self.typeRequiresOnboarding(type) == true: "Onboarding is not needed for this type"
+            FlowEVMBridgeUtils.typeAllowsBridging(type):
+            "This Cadence Type \(type.identifier) is currently opted-out of bridge onboarding"
+            FlowEVMBridgeUtils.isCadenceNative(type: type): "Only Cadence-native assets can be onboarded by Type"
+        }
+        /* Custom cross-VM Implementation check */
+        //
+        // Register as a custom cross-VM implementation if detected
+        if FlowEVMBridgeUtils.getEVMPointerView(forType: type) != nil {
+            self.registerCrossVMNFT(type: type, fulfillmentMinter: nil, feeProvider: feeProvider)
+            return
+        }
+
+        /* Provision fees */
+        //
+        // Withdraw from feeProvider and deposit to self
+        FlowEVMBridgeUtils.depositFee(feeProvider, feeAmount: FlowEVMBridgeConfig.onboardFee)
+
+        /* EVM setup */
+        //
+        // Deploy an EVM defining contract via the FlowBridgeFactory.sol contract
+        let onboardingValues = self.deployEVMContract(forAssetType: type)
+
+        /* Cadence escrow setup */
+        //
+        // Initialize bridge escrow for the asset based on its type
+        if type.isSubtype(of: Type<@{NonFungibleToken.NFT}>()) {
+            FlowEVMBridgeNFTEscrow.initializeEscrow(
+                forType: type,
+                name: onboardingValues.name,
+                symbol: onboardingValues.symbol,
+                erc721Address: onboardingValues.evmContractAddress
+            )
+        } else if type.isSubtype(of: Type<@{FungibleToken.Vault}>()) {
+            let createVaultFunction = FlowEVMBridgeUtils.getCreateEmptyVaultFunction(forType: type)
+                ?? panic("Could not retrieve createEmptyVault function for the given type")
+            let vault <-createVaultFunction(type)
+            assert(
+                vault.getType() == type,
+                message: "Requested to onboard type=\(type.identifier) but contract returned type=\(vault.getType().identifier)"
+            )
+            FlowEVMBridgeTokenEscrow.initializeEscrow(
+                with: <-vault,
+                name: onboardingValues.name,
+                symbol: onboardingValues.symbol,
+                decimals: onboardingValues.decimals!,
+                evmTokenAddress: onboardingValues.evmContractAddress
+            )
+        } else {
+            panic("Attempted to onboard unsupported type: \(type.identifier)")
+        }
+
+        /* Confirmation */
+        //
+        assert(
+            FlowEVMBridgeNFTEscrow.isInitialized(forType: type) || FlowEVMBridgeTokenEscrow.isInitialized(forType: type),
+            message: "Failed to initialize escrow for given type"
+        )
+
+        emit Onboarded(
+            type: type.identifier,
+            cadenceContractAddress: FlowEVMBridgeUtils.getContractAddress(fromType: type)!,
+            evmContractAddress: onboardingValues.evmContractAddress.toString()
+        )
+    }
+
+    /// Onboards a given EVM contract to the bridge. Since we're onboarding by EVM Address, the asset must be defined in
+    /// a third-party EVM contract. Attempting to onboard a bridge-defined asset will result in an error as onboarding
+    /// is not required.
+    ///
+    /// @param address: The EVMAddress of the ERC721 or ERC20 to be onboarded
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    ///
+    access(all)
+    fun onboardByEVMAddress(
+        _ address: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        pre {
+            !FlowEVMBridgeConfig.isPaused(): "Bridge operations are currently paused"
+            !FlowEVMBridgeConfig.isEVMAddressBlocked(address):
+                "This EVM contract \(address.toString()) is currently blocked from being onboarded"
+        }
+        /* Custom cross-VM Implementation check */
+        //
+        let cadenceAddr = FlowEVMBridgeUtils.getDeclaredCadenceAddressFromCrossVM(evmContract: address)
+        let cadenceType = FlowEVMBridgeUtils.getDeclaredCadenceTypeFromCrossVM(evmContract: address)
+        // Register as a custom cross-VM implementation if detected
+        if cadenceAddr != nil && cadenceType != nil {
+            self.registerCrossVMNFT(type: cadenceType!, fulfillmentMinter: nil, feeProvider: feeProvider)
+            return
+        }
+
+        /* Validate the EVM contract */
+        //
+        // Ensure the project has not opted out of bridge support
+        assert(
+            FlowEVMBridgeUtils.evmAddressAllowsBridging(address),
+            message: "This contract is not supported as defined by the project's development team"
+        )
+        assert(
+            self.evmAddressRequiresOnboarding(address) == true,
+            message: "Onboarding is not needed for this contract"
+        )
+
+        /* Provision fees */
+        //
+        // Withdraw fee from feeProvider and deposit
+        FlowEVMBridgeUtils.depositFee(feeProvider, feeAmount: FlowEVMBridgeConfig.onboardFee)
+
+        /* Setup Cadence-defining contract */
+        //
+        // Deploy a defining Cadence contract to the bridge account
+        self.deployDefiningContract(evmContractAddress: address)
+    }
+
+    /// Registers a custom cross-VM NFT implementation, allowing projects to integrate their Cadence & EVM contracts
+    /// such that the VM bridge facilitates movement between VMs as the integrated implementations.
+    ///
+    /// @param type: The NFT Type to register as cross-VM NFT
+    /// @param fulfillmentMinter: The optional NFTFulfillmentMinter Capability. This parameter is required for
+    ///     EVM-native NFTs
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    ///
+    access(all)
+    fun registerCrossVMNFT(
+        type: Type,
+        fulfillmentMinter: Capability<auth(FlowEVMBridgeCustomAssociationTypes.FulfillFromEVM) &{FlowEVMBridgeCustomAssociationTypes.NFTFulfillmentMinter}>?,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        pre {
+            FlowEVMBridgeUtils.typeAllowsBridging(type):
+            "This Cadence Type \(type.identifier) is currently opted-out of bridge onboarding"
+            type.isSubtype(of: Type<@{NonFungibleToken.NFT}>()):
+            "The provided Type \(type.identifier) is not an NFT - only NFTs can register as cross-VM"
+            !type.isSubtype(of: Type<@{FungibleToken.Vault}>()):
+            "The provided Type \(type.identifier) is also a FungibleToken Vault - only NFTs can register as cross-VM"
+            !FlowEVMBridgeConfig.isCadenceTypeBlocked(type):
+            "Type \(type.identifier) has been blocked from onboarding"
+            FlowEVMBridgeUtils.isCadenceNative(type: type):
+            "Attempting to register a bridge-deployed NFT - cannot update a bridge-defined asset. If updating your EVM contract's Cadence association, deploy your Cadence NFT contract and register using the newly defined Cadence type"
+            FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type) == nil:
+            "A custom association has already been declared for type \(type.identifier) with EVM address \(FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type)!.toString()). Custom associations can only be declared once for any given Cadence Type or EVM contract"
+            fulfillmentMinter?.check() ?? true:
+            "NFTFulfillmentMinter Capability is invalid - Issue a new Capability<auth(FlowEVMBridgeCustomAssociationTypes.FulfillFromEVM) &{FlowEVMBridgeCustomAssociationTypes.NFTFulfillmentMinter}> and try again"
+            fulfillmentMinter != nil ? fulfillmentMinter!.borrow()!.getType().address! == type.address! : true:
+            "NFTFulfillmentMinter must be defined by a contract deployed to the registered type address \(type.address!) but found defining address of \(fulfillmentMinter!.borrow()!.getType().address!)"
+        }
+        /* Provision fees */
+        //
+        // Withdraw fee from feeProvider and deposit
+        FlowEVMBridgeUtils.depositFee(feeProvider, feeAmount: FlowEVMBridgeConfig.onboardFee)
+
+        /* Get pointers from both contracts */
+        //
+        // Get the Cadence side EVMPointer
+        let evmPointer = FlowEVMBridgeUtils.getEVMPointerView(forType: type)
+            ?? panic("The CrossVMMetadataViews.EVMPointer is not supported by the type \(type.identifier).")
+        // EVM contract checks
+        assert(!FlowEVMBridgeConfig.isEVMAddressBlocked(evmPointer.evmContractAddress),
+            message: "Type \(type.identifier) has been blocked from onboarding.")
+        assert(
+            FlowEVMBridgeUtils.evmAddressAllowsBridging(evmPointer.evmContractAddress),
+            message: "The EVM contract \(evmPointer.evmContractAddress.toString()) developers have opted out of VM bridge integration."
+        )
+        assert(
+            FlowEVMBridgeCustomAssociations.getTypeAssociated(with: evmPointer.evmContractAddress) == nil,
+            message: "A custom association has already been declared for EVM address \(evmPointer.evmContractAddress.toString()) with Cadence Type \(FlowEVMBridgeCustomAssociations.getTypeAssociated(with: evmPointer.evmContractAddress)?.identifier ?? "<UNKNOWN>"). Custom associations can only be declared once for any given Cadence Type or EVM contract"
+        )
+        assert(
+            FlowEVMBridgeUtils.isERC721(evmContractAddress: evmPointer.evmContractAddress)
+            && !FlowEVMBridgeUtils.isERC20(evmContractAddress: evmPointer.evmContractAddress),
+            message: "Cross-VM NFTs must be implemented as ERC721 exclusively, but detected an invalid EVM interface at EVM contract \(evmPointer.evmContractAddress.toString())"
+        )
+
+        // Get pointer on EVM side
+        let cadenceAddr = FlowEVMBridgeUtils.getDeclaredCadenceAddressFromCrossVM(evmContract: evmPointer.evmContractAddress)
+            ?? panic("Could not retrieve a Cadence address declaration from the EVM contract \(evmPointer.evmContractAddress.toString())")
+        let cadenceType = FlowEVMBridgeUtils.getDeclaredCadenceTypeFromCrossVM(evmContract: evmPointer.evmContractAddress)
+            ?? panic("Could not retrieve a Cadence Type declaration from the EVM contract \(evmPointer.evmContractAddress.toString())")
+
+        /* Pointer validation */
+        //
+        // Assert both point to each other
+        assert(
+            type.address == cadenceAddr,
+            message: "Mismatched Cadence Address pointers: \(type.address!.toString()) and \(cadenceAddr.toString())"
+        )
+        assert(
+            type == cadenceType,
+            message: "Mismatched type pointers: \(type.identifier) and \(cadenceType.identifier)"
+        )
+
+        /* Cross-VM conformance check */
+        //
+        // Check supportsInterface() for CrossVMBridgeERC721Fulfillment if NFT is Cadence-native
+        if evmPointer.nativeVM == CrossVMMetadataViews.VM.Cadence {
+            assert(FlowEVMBridgeUtils.supportsCadenceNativeNFTEVMInterfaces(evmContract: evmPointer.evmContractAddress),
+                message: "Corresponding EVM contract does not implement necessary EVM interfaces ICrossVMBridgeERC721Fulfillment and/or ICrossVMBridgeCallable. All Cadence-native cross-VM NFTs must implement these interfaces and grant the bridge COA the ability to fulfill bridge requests moving NFTs into EVM.")
+            let designatedVMBridgeAddress = FlowEVMBridgeUtils.getVMBridgeAddressFromICrossVMBridgeCallable(evmContract: evmPointer.evmContractAddress)
+                ?? panic("Could not recover declared VM bridge address from EVM contract \(evmPointer.evmContractAddress.toString()). Ensure the contract conforms to ICrossVMBridgeCallable and declare the vmBridgeAddress as \(FlowEVMBridgeUtils.getBridgeCOAEVMAddress().toString())")
+            assert(designatedVMBridgeAddress.equals(FlowEVMBridgeUtils.getBridgeCOAEVMAddress()),
+                message: "ICrossVMBridgeCallable declared \(designatedVMBridgeAddress.toString()) as vmBridgeAddress which must be declared as \(FlowEVMBridgeUtils.getBridgeCOAEVMAddress().toString())")
+        }
+
+        /* Native VM consistency check */
+        //
+        // Assess if the NFT has been previously onboarded to the bridge
+        let legacyEVMAssoc = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: type)
+        let legacyCadenceAssoc = FlowEVMBridgeConfig.getLegacyTypeAssociated(with: evmPointer.evmContractAddress)
+        assert(legacyEVMAssoc == nil || legacyCadenceAssoc == nil,
+            message: "Both the EVM contract \(evmPointer.evmContractAddress.toString()) and the Cadence Type \(type.identifier) have already been onboarded to the VM bridge - one side of this association will have to be redeployed and the declared association updated to a non-onboarded target in order to register as a custom cross-VM asset.")
+        // Ensure the native VM is consistent if the NFT has been previously onboarded via the permissionless path
+        if legacyEVMAssoc != nil {
+            assert(evmPointer.nativeVM == CrossVMMetadataViews.VM.Cadence,
+                message: "Attempting to register NFT \(type.identifier) as EVM-native after it has already been onboarded as Cadence-native. This NFT must be configured as Cadence-native with an ERC721 implementing CrossVMBridgeERC721Fulfillment base contract allowing the bridge to fulfill NFTs moving into EVM")
+        } else if legacyCadenceAssoc != nil {
+            assert(evmPointer.nativeVM == CrossVMMetadataViews.VM.EVM,
+                message: "Attempting to register NFT \(type.identifier) as Cadence-native after it has already been onboarded as EVM-native. This NFT must be configured as EVM-native and provide an NFTFulfillmentMinter Capability so the bridge may fulfill NFTs moving into Cadence.")
+        }
+
+        FlowEVMBridgeCustomAssociations.saveCustomAssociation(
+            type: type,
+            evmContractAddress: evmPointer.evmContractAddress,
+            nativeVM: evmPointer.nativeVM,
+            updatedFromBridged: legacyEVMAssoc != nil || legacyCadenceAssoc != nil,
+            fulfillmentMinter: fulfillmentMinter
+        )
+
+        if !FlowEVMBridgeNFTEscrow.isInitialized(forType: type) {
+            let name = FlowEVMBridgeUtils.getName(evmContractAddress: evmPointer.evmContractAddress)
+            let symbol = FlowEVMBridgeUtils.getSymbol(evmContractAddress: evmPointer.evmContractAddress)
+            FlowEVMBridgeNFTEscrow.initializeEscrow(
+                forType: type,
+                name: name,
+                symbol: symbol,
+                erc721Address: evmPointer.evmContractAddress
+            )
+        }
+    }
+
+    /*************************
+        NFT Handling
+    **************************/
+
+    /// Public entrypoint to bridge NFTs from Cadence to EVM as ERC721.
+    ///
+    /// @param token: The NFT to be bridged
+    /// @param to: The NFT recipient in FlowEVM
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    ///
+    access(all)
+    fun bridgeNFTToEVM(
+        token: @{NonFungibleToken.NFT},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        pre {
+            !FlowEVMBridgeConfig.isPaused(): "Bridge operations are currently paused"
+            !token.isInstance(Type<@{FungibleToken.Vault}>()): "Mixed asset types are not yet supported"
+            self.typeRequiresOnboarding(token.getType()) == false: "NFT must first be onboarded"
+            FlowEVMBridgeConfig.isTypePaused(token.getType()) == false: "Bridging is currently paused for this NFT"
+        }
+        let bridgedAssoc = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: token.getType())
+        let customAssocByType = FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: token.getType())
+        let customAssocByEVMAddr =  bridgedAssoc != nil ? FlowEVMBridgeCustomAssociations.getTypeAssociated(with: bridgedAssoc!) : nil
+        if bridgedAssoc != nil && customAssocByType == nil && customAssocByEVMAddr == nil {
+            // Common case - bridge-defined counterpart in non-native VM
+            return self.handleDefaultNFTToEVM(token: <-token, to: to, feeProvider: feeProvider)
+        } else if customAssocByType != nil && customAssocByEVMAddr == nil {
+            // NFT is registered as cross-VM
+            return self.handleCrossVMNFTToEVM(token: <-token, to: to, feeProvider: feeProvider)
+        } else if customAssocByType == nil && customAssocByEVMAddr != nil {
+            // Dealing with a bridge-defined NFT after a custom association has been configured
+            return self.handleUpdatedBridgedNFTToEVM(token: <-token, to: to, feeProvider: feeProvider)
+        }
+        // customAssocByType != nil && customAssocByEVMAddr != nil
+        panic("Unknown error encountered bridging NFT \(token.getType().identifier) with ID \(token.id) to EVM recipient \(to.toString())")
+    }
+
+    /// Entrypoint to bridge ERC721 from EVM to Cadence as NonFungibleToken.NFT
+    ///
+    /// @param owner: The EVM address of the NFT owner. Current ownership and successful transfer (via
+    ///     `protectedTransferCall`) is validated before the bridge request is executed.
+    /// @param calldata: Caller-provided approve() call, enabling contract COA to operate on NFT in EVM contract
+    /// @param id: The NFT ID to bridged
+    /// @param evmContractAddress: Address of the EVM address defining the NFT being bridged - also call target
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    /// @param protectedTransferCall: A function that executes the transfer of the NFT from the named owner to the
+    ///     bridge's COA. This function is expected to return a Result indicating the status of the transfer call.
+    ///
+    /// @returns The bridged NFT
+    ///
+    access(account)
+    fun bridgeNFTFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        id: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (EVM.EVMAddress): EVM.ResultDecoded
+    ): @{NonFungibleToken.NFT} {
+        pre {
+            !FlowEVMBridgeConfig.isPaused(): "Bridge operations are currently paused"
+            !type.isSubtype(of: Type<@{FungibleToken.Vault}>()): "Mixed asset types are not yet supported"
+            self.typeRequiresOnboarding(type) == false: "NFT must first be onboarded"
+            FlowEVMBridgeConfig.isTypePaused(type) == false: "Bridging is currently paused for this NFT"
+        }
+        let bridgedAssoc = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: type)
+        let customAssocByType = FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type)
+        let customAssocByEVMAddr =  bridgedAssoc != nil ? FlowEVMBridgeCustomAssociations.getTypeAssociated(with: bridgedAssoc!) : nil
+        // Initialize the internal handler method that will be used to move the NFT from EVM
+        var handler: (fun (EVM.EVMAddress, Type, UInt256, auth(FungibleToken.Withdraw) &{FungibleToken.Provider}, fun (EVM.EVMAddress): EVM.ResultDecoded): @{NonFungibleToken.NFT})? = nil
+        if bridgedAssoc != nil && customAssocByType == nil && customAssocByEVMAddr == nil {
+            // Common case - bridge-defined counterpart in non-native VM
+            handler = self.handleDefaultNFTFromEVM
+        } else if customAssocByType != nil && customAssocByEVMAddr == nil {
+            // NFT is registered as cross-VM
+            handler = self.handleCrossVMNFTFromEVM
+        } else if customAssocByType == nil && customAssocByEVMAddr != nil {
+            // Dealing with a bridge-defined NFT after a custom association has been configured
+            handler = self.handleUpdatedBridgedNFTFromEVM
+        } else {
+            // customAssocByType != nil && customAssocByEVMAddr != nil
+            panic("Unknown error encountered bridging NFT \(type.identifier) with ID \(id) from EVM owner \(owner.toString())")
+        }
+        // Return the bridged NFT, using the appropriate handler
+        return <- handler!(owner: owner, type: type, id: id, feeProvider: feeProvider, protectedTransferCall: protectedTransferCall)
+    }
+
+    /**************************
+        FT Handling
+    ***************************/
+
+    /// Public entrypoint to bridge FTs from Cadence to EVM as ERC20 tokens.
+    ///
+    /// @param vault: The fungible token Vault to be bridged
+    /// @param to: The fungible token recipient in EVM
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    ///
+    access(all)
+    fun bridgeTokensToEVM(
+        vault: @{FungibleToken.Vault},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        pre {
+            !FlowEVMBridgeConfig.isPaused(): "Bridge operations are currently paused"
+            !vault.isInstance(Type<@{NonFungibleToken.NFT}>()): "Mixed asset types are not yet supported"
+            self.typeRequiresOnboarding(vault.getType()) == false: "FungibleToken must first be onboarded"
+            FlowEVMBridgeConfig.isTypePaused(vault.getType()) == false: "Bridging is currently paused for this token"
+        }
+        /* Handle $FLOW requests via EVM interface & return */
+        //
+        let vaultType = vault.getType()
+
+        // Gather the vault balance before acting on the resource
+        let vaultBalance = vault.balance
+        // Initialize fee amount to 0.0 and assign as appropriate for how the token is handled
+        var feeAmount = 0.0
+
+        /* TokenHandler coverage */
+        //
+        // Some tokens pre-dating bridge require special case handling - borrow handler and passthrough to fulfill
+        if FlowEVMBridgeConfig.typeHasTokenHandler(vaultType) {
+            let handler = FlowEVMBridgeConfig.borrowTokenHandler(vaultType)
+                ?? panic("Could not retrieve handler for the given type")
+            handler.fulfillTokensToEVM(tokens: <-vault, to: to)
+
+            // Here we assume burning Vault in Cadence which doesn't require storage consumption
+            feeAmount = FlowEVMBridgeUtils.calculateBridgeFee(bytes: 0)
+            FlowEVMBridgeUtils.depositFee(feeProvider, feeAmount: feeAmount)
+            return
+        }
+
+        /* Escrow or burn tokens depending on native environment */
+        //
+        // In most all other cases, if Cadence-native then tokens must be escrowed
+        if FlowEVMBridgeUtils.isCadenceNative(type: vaultType) {
+            // Lock the FT balance & calculate the extra used by the FT if any
+            let storageUsed = FlowEVMBridgeTokenEscrow.lockTokens(<-vault)
+            // Calculate the bridge fee on current rates
+            feeAmount = FlowEVMBridgeUtils.calculateBridgeFee(bytes: storageUsed)
+        } else {
+            // Since not Cadence-native, bridge defines the token - burn the vault and calculate the fee
+            Burner.burn(<-vault)
+            feeAmount = FlowEVMBridgeUtils.calculateBridgeFee(bytes: 0)
+        }
+
+        /* Provision fees */
+        //
+        // Withdraw fee amount from feeProvider and deposit
+        FlowEVMBridgeUtils.depositFee(feeProvider, feeAmount: feeAmount)
+
+        /* Gather identifying information */
+        //
+        // Does the bridge control the EVM contract associated with this type?
+        let associatedAddress = FlowEVMBridgeConfig.getEVMAddressAssociated(with: vaultType)
+            ?? panic("No EVMAddress found for vault type")
+        // Convert the vault balance to a UInt256
+        let bridgeAmount = FlowEVMBridgeUtils.convertCadenceAmountToERC20Amount(
+                vaultBalance,
+                erc20Address: associatedAddress
+            )
+        assert(bridgeAmount > UInt256(0), message: "Amount to bridge must be greater than 0")
+
+        // Determine if the EVM contract is bridge-owned - affects how tokens are transmitted to recipient
+        let isFactoryDeployed = FlowEVMBridgeUtils.isEVMContractBridgeOwned(evmContractAddress: associatedAddress)
+
+        /* Transmit tokens to recipient */
+        //
+        // Mint or transfer based on the bridge's EVM contract authority, making needed state assertions to confirm
+        if isFactoryDeployed {
+            FlowEVMBridgeUtils.mustMintERC20(to: to, amount: bridgeAmount, erc20Address: associatedAddress)
+        } else {
+            FlowEVMBridgeUtils.mustTransferERC20(to: to, amount: bridgeAmount, erc20Address: associatedAddress)
+        }
+    }
+
+    /// Entrypoint to bridge ERC20 tokens from EVM to Cadence as FungibleToken Vaults
+    ///
+    /// @param owner: The EVM address of the FT owner. Current ownership and successful transfer (via
+    ///     `protectedTransferCall`) is validated before the bridge request is executed.
+    /// @param calldata: Caller-provided approve() call, enabling contract COA to operate on FT in EVM contract
+    /// @param amount: The amount of tokens to be bridged
+    /// @param evmContractAddress: Address of the EVM address defining the FT being bridged - also call target
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    /// @param protectedTransferCall: A function that executes the transfer of the FT from the named owner to the
+    ///     bridge's COA. This function is expected to return a Result indicating the status of the transfer call.
+    ///
+    /// @returns The bridged fungible token Vault
+    ///
+    access(account)
+    fun bridgeTokensFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        amount: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (): EVM.ResultDecoded
+    ): @{FungibleToken.Vault} {
+        pre {
+            !FlowEVMBridgeConfig.isPaused(): "Bridge operations are currently paused"
+            !type.isSubtype(of: Type<@{NonFungibleToken.Collection}>()): "Mixed asset types are not yet supported"
+            self.typeRequiresOnboarding(type) == false: "FungibleToken must first be onboarded"
+            FlowEVMBridgeConfig.isTypePaused(type) == false: "Bridging is currently paused for this token"
+        }
+        /* Provision fees */
+        //
+        // Withdraw from feeProvider and deposit to self
+        let feeAmount = FlowEVMBridgeUtils.calculateBridgeFee(bytes: 0)
+        FlowEVMBridgeUtils.depositFee(feeProvider, feeAmount: feeAmount)
+
+        /* TokenHandler case coverage */
+        //
+        // Some tokens pre-dating bridge require special case handling. If such a case, fulfill via the related handler
+        if FlowEVMBridgeConfig.typeHasTokenHandler(type) {
+            //  - borrow handler and passthrough to fulfill
+            let handler = FlowEVMBridgeConfig.borrowTokenHandler(type)
+                ?? panic("Could not retrieve handler for the given type")
+            return <-handler.fulfillTokensFromEVM(
+                owner: owner,
+                type: type,
+                amount: amount,
+                protectedTransferCall: protectedTransferCall
+            )
+        }
+
+        /* Gather identifying information */
+        //
+        // Get the EVMAddress of the ERC20 contract associated with the type
+        let associatedAddress = FlowEVMBridgeConfig.getEVMAddressAssociated(with: type)
+            ?? panic("No EVMAddress found for token type")
+        // Find the Cadence defining address and contract name
+        let definingAddress = FlowEVMBridgeUtils.getContractAddress(fromType: type)!
+        let definingContractName = FlowEVMBridgeUtils.getContractName(fromType: type)!
+        // Convert the amount to a ufix64 so the amount can be settled on the Cadence side
+        let ufixAmount = FlowEVMBridgeUtils.convertERC20AmountToCadenceAmount(amount, erc20Address: associatedAddress)
+        assert(ufixAmount > 0.0, message: "Amount to bridge must be greater than 0")
+
+        /* Execute the transfer call and make needed state assertions */
+        //
+        FlowEVMBridgeUtils.mustEscrowERC20(
+            owner: owner,
+            amount: amount,
+            erc20Address: associatedAddress,
+            protectedTransferCall: protectedTransferCall
+        )
+
+        /* Bridge-defined tokens are minted in Cadence */
+        //
+        // If the Cadence Vault is bridge-defined, mint the tokens
+        if definingAddress == self.account.address {
+            let minter = getAccount(definingAddress).contracts.borrow<&{IEVMBridgeTokenMinter}>(name: definingContractName)!
+            return <- minter.mintTokens(amount: ufixAmount)
+        }
+
+        /* Cadence-native tokens are withdrawn from escrow */
+        //
+        // Confirm the EVM defining contract is bridge-owned before burning tokens
+        assert(
+            FlowEVMBridgeUtils.isEVMContractBridgeOwned(evmContractAddress: associatedAddress),
+            message: "Unexpected error bridging FT from EVM"
+        )
+        // Burn the EVM tokens that have now been transferred to the bridge in EVM
+        let burnResult = FlowEVMBridgeUtils.callWithSigAndArgs(
+            signature: "burn(uint256)",
+            targetEVMAddress: associatedAddress,
+            args: [amount],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(burnResult.status == EVM.Status.successful, message: "Burn of EVM tokens failed")
+
+        // Unlock from escrow and return
+        return <-FlowEVMBridgeTokenEscrow.unlockTokens(type: type, amount: ufixAmount)
+    }
+
+    /**************************
+        Public Getters
+    **************************/
+
+    /// Returns the EVM address associated with the provided type
+    ///
+    access(all)
+    view fun getAssociatedEVMAddress(with type: Type): EVM.EVMAddress? {
+        return FlowEVMBridgeConfig.getEVMAddressAssociated(with: type)
+    }
+
+    /// Retrieves the bridge contract's COA EVMAddress
+    ///
+    /// @returns The EVMAddress of the bridge contract's COA orchestrating actions in FlowEVM
+    ///
+    access(all)
+    view fun getBridgeCOAEVMAddress(): EVM.EVMAddress {
+        return FlowEVMBridgeUtils.borrowCOA().address()
+    }
+
+    /// Returns whether an asset needs to be onboarded to the bridge
+    ///
+    /// @param type: The Cadence Type of the asset
+    ///
+    /// @returns Whether the asset needs to be onboarded
+    ///
+    access(all)
+    view fun typeRequiresOnboarding(_ type: Type): Bool? {
+        if !FlowEVMBridgeUtils.isValidCadenceAsset(type: type) {
+            return nil
+        }
+        return FlowEVMBridgeConfig.getEVMAddressAssociated(with: type) == nil &&
+            !FlowEVMBridgeConfig.typeHasTokenHandler(type)
+    }
+
+    /// Returns whether an EVM-native asset needs to be onboarded to the bridge
+    ///
+    /// @param address: The EVMAddress of the asset
+    ///
+    /// @returns Whether the asset needs to be onboarded, nil if the defined asset is not supported by this bridge
+    ///
+    access(all)
+    fun evmAddressRequiresOnboarding(_ address: EVM.EVMAddress): Bool? {
+        // See if the bridge already has a known type associated with the given address
+        if FlowEVMBridgeConfig.getTypeAssociated(with: address) != nil {
+            return false
+        }
+        // Dealing with EVM-native asset, check if it's NFT or FT exclusively
+        if FlowEVMBridgeUtils.isValidEVMAsset(evmContractAddress: address) {
+            return true
+        }
+        // Not onboarded and not a valid asset, so return nil
+        return nil
+    }
+
+    /**************************
+        Internal Helpers
+    ***************************/
+
+    /// Deploys templated EVM contract via Solidity Factory contract supporting bridging of a given asset type
+    ///
+    /// @param forAssetType: The Cadence Type of the asset
+    ///
+    /// @returns The EVMAddress of the deployed contract
+    ///
+    access(self)
+    fun deployEVMContract(forAssetType: Type): FlowEVMBridgeUtils.EVMOnboardingValues {
+        pre {
+            FlowEVMBridgeUtils.isValidCadenceAsset(type: forAssetType):
+                "Asset type is not supported by the bridge"
+        }
+        let isNFT = forAssetType.isSubtype(of: Type<@{NonFungibleToken.NFT}>())
+
+        let onboardingValues = FlowEVMBridgeUtils.getCadenceOnboardingValues(forAssetType: forAssetType)
+
+        let deployedContractAddress = FlowEVMBridgeUtils.mustDeployEVMContract(
+                name: onboardingValues.name,
+                symbol: onboardingValues.symbol,
+                cadenceAddress: onboardingValues.contractAddress,
+                flowIdentifier: onboardingValues.identifier,
+                contractURI: onboardingValues.contractURI,
+                isERC721: isNFT
+            )
+
+        // Associate the deployed contract with the given type & return the deployed address
+        FlowEVMBridgeConfig.associateType(forAssetType, with: deployedContractAddress)
+        return FlowEVMBridgeUtils.EVMOnboardingValues(
+            evmContractAddress: deployedContractAddress,
+            name: onboardingValues.name,
+            symbol: onboardingValues.symbol,
+            decimals: isNFT ? nil : FlowEVMBridgeConfig.defaultDecimals,
+            contractURI: onboardingValues.contractURI,
+            cadenceContractName: FlowEVMBridgeUtils.getContractName(fromType: forAssetType)!,
+            isERC721: isNFT
+        )
+    }
+
+    /// Helper for deploying templated defining contract supporting EVM-native asset bridging to Cadence
+    /// Deploys either NFT or FT contract depending on the provided type
+    ///
+    /// @param evmContractAddress: The EVMAddress currently defining the asset to be bridged
+    ///
+    access(self)
+    fun deployDefiningContract(evmContractAddress: EVM.EVMAddress) {
+        // Gather identifying information about the EVM contract
+        let evmOnboardingValues = FlowEVMBridgeUtils.getEVMOnboardingValues(evmContractAddress: evmContractAddress)
+
+        // Get Cadence code from template & deploy to the bridge account
+        let cadenceCode: [UInt8] = FlowEVMBridgeTemplates.getBridgedAssetContractCode(
+                evmOnboardingValues.cadenceContractName,
+                isERC721: evmOnboardingValues.isERC721
+            ) ?? panic("Problem retrieving code for Cadence-defining contract")
+        if evmOnboardingValues.isERC721 {
+            self.account.contracts.add(
+                name: evmOnboardingValues.cadenceContractName,
+                code: cadenceCode,
+                evmOnboardingValues.name,
+                evmOnboardingValues.symbol,
+                evmContractAddress,
+                evmOnboardingValues.contractURI
+            )
+        } else {
+            self.account.contracts.add(
+                name: evmOnboardingValues.cadenceContractName,
+                code: cadenceCode,
+                evmOnboardingValues.name,
+                evmOnboardingValues.symbol,
+                evmOnboardingValues.decimals!,
+                evmContractAddress, evmOnboardingValues.contractURI
+            )
+        }
+
+        emit BridgeDefiningContractDeployed(
+            contractName: evmOnboardingValues.cadenceContractName,
+            assetName: evmOnboardingValues.name,
+            symbol: evmOnboardingValues.symbol,
+            isERC721: evmOnboardingValues.isERC721,
+            evmContractAddress: evmContractAddress.toString()
+        )
+    }
+
+    /// Escrows the provided NFT and withdraws the bridging fee on the basis of a base fee + storage fee
+    ///
+    access(self)
+    fun escrowNFTAndWithdrawFee(
+        token: @{NonFungibleToken.NFT},
+        from: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        // Lock the NFT & calculate the storage used by the NFT
+        let storageUsed = FlowEVMBridgeNFTEscrow.lockNFT(<-token)
+        // Calculate the bridge fee on current rates
+        let feeAmount = FlowEVMBridgeUtils.calculateBridgeFee(bytes: storageUsed)
+        // Withdraw fee from feeProvider and deposit
+        FlowEVMBridgeUtils.depositFee(from, feeAmount: feeAmount)
+    }
+
+    /// Handle permissionlessly onboarded NFTs where the bridge deployed and manages the non-native contract
+    ///
+    access(self)
+    fun handleDefaultNFTToEVM(
+        token: @{NonFungibleToken.NFT},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        /* Gather identifying information */
+        //
+        let tokenType = token.getType()
+        let tokenID = token.id
+        let evmID = CrossVMNFT.getEVMID(from: &token as &{NonFungibleToken.NFT}) ?? UInt256(token.id)
+
+        /* Metadata assignment */
+        //
+        // Grab the URI from the NFT if available
+        var uri: String = ""
+        var symbol: String = ""
+        // Default to project-specified URI
+        if let metadata = token.resolveView(Type<MetadataViews.EVMBridgedMetadata>()) as! MetadataViews.EVMBridgedMetadata? {
+            uri = metadata.uri.uri()
+            symbol = metadata.symbol
+        } else {
+            // Otherwise, serialize the NFT
+            uri = SerializeMetadata.serializeNFTMetadataAsURI(&token as &{NonFungibleToken.NFT})
+        }
+
+        /* Secure NFT in escrow & deposit calculated fees */
+        //
+        // Withdraw fee from feeProvider and deposit
+        self.escrowNFTAndWithdrawFee(token: <-token, from: feeProvider)
+
+        /* Determine EVM handling */
+        //
+        // Does the bridge control the EVM contract associated with this type?
+        let associatedAddress = FlowEVMBridgeConfig.getEVMAddressAssociated(with: tokenType)
+            ?? panic("No EVMAddress found for token type")
+        let isFactoryDeployed = FlowEVMBridgeUtils.isEVMContractBridgeOwned(evmContractAddress: associatedAddress)
+
+        /* Third-party controlled ERC721 handling */
+        //
+        // Not bridge-controlled, transfer existing ownership
+        if !isFactoryDeployed {
+            FlowEVMBridgeUtils.mustSafeTransferERC721(erc721Address: associatedAddress, to: to, id: evmID)
+            return
+        }
+
+        /* Bridge-owned ERC721 handling */
+        //
+        // Check if the ERC721 exists in the EVM contract - determines if bridge mints or transfers
+        let exists = FlowEVMBridgeUtils.erc721Exists(erc721Address: associatedAddress, id: evmID)
+        if exists {
+            // Transfer the existing NFT & update the URI to reflect current metadata
+            FlowEVMBridgeUtils.mustSafeTransferERC721(erc721Address: associatedAddress, to: to, id: evmID)
+            FlowEVMBridgeUtils.mustUpdateTokenURI(erc721Address: associatedAddress, id: evmID, uri: uri)
+        } else {
+            // Otherwise mint with current URI
+            FlowEVMBridgeUtils.mustSafeMintERC721(erc721Address: associatedAddress, to: to, id: evmID, uri: uri)
+        }
+        // Update the bridged ERC721 symbol if different than the Cadence-defined EVMBridgedMetadata.symbol
+        if symbol.length > 0 && symbol != FlowEVMBridgeUtils.getSymbol(evmContractAddress: associatedAddress) {
+            FlowEVMBridgeUtils.tryUpdateSymbol(associatedAddress, symbol: symbol)
+        }
+        
+    }
+
+    /// Handler to move registered cross-VM NFTs to EVM
+    ///
+    access(self)
+    fun handleCrossVMNFTToEVM(
+        token: @{NonFungibleToken.NFT},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}) {
+        let evmPointer = FlowEVMBridgeCustomAssociations.getEVMPointerAsRegistered(forType: token.getType())
+            ?? panic("Could not find custom association for cross-VM NFT \(token.getType().identifier) with id \(token.id). Ensure this NFT has been registered as a cross-VM.")
+        return evmPointer.nativeVM == CrossVMMetadataViews.VM.Cadence ?
+            self.handleCadenceNativeCrossVMNFTToEVM(token: <-token, to: to, feeProvider: feeProvider) :
+            self.handleEVMNativeCrossVMNFTToEVM(token: <-token, to: to, feeProvider: feeProvider)
+    }
+
+    /// Handler to move registered cross-VM Cadence-native NFTs to EVM
+    ///
+    access(self)
+    fun handleCadenceNativeCrossVMNFTToEVM(
+        token: @{NonFungibleToken.NFT},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        let type = token.getType()
+        let id = UInt256(token.id)
+
+        // Check on permissionlessly onboarded association & bridged token existence
+        if let bridgedERC721 = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: type) {
+            // Burn bridged ERC721 if exists - will be replaced by custom ERC721 implementation
+            if FlowEVMBridgeUtils.erc721Exists(erc721Address: bridgedERC721, id: id) {
+                FlowEVMBridgeUtils.mustBurnERC721(erc721Address: bridgedERC721, id: id)
+            }
+        }
+        // Make ICrossVMBridgeERC721Fulfillment.fulfillToEVM call, passing any metadata resolved by the NFT allowing
+        // the ERC721 implementation to update metadata if needed. The base CrossVMBridgeERC721Fulfillment contract
+        // checks for existence and mints if needed or transfers from vm bridge escrow, following a mint/escrow
+        // pattern.
+        let customERC721 = FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type)!
+        let data = CrossVMMetadataViews.getEVMBytesMetadata(&token as &{ViewResolver.Resolver})
+        FlowEVMBridgeUtils.mustFulfillNFTToEVM(erc721Address: customERC721, to: to, id: id, maybeBytes: data?.bytes)
+
+        // Escrow the NFT & charge the bridge fee
+        self.escrowNFTAndWithdrawFee(token: <-token, from: feeProvider)
+    }
+
+    /// Handler to move cross-VM EVM-native NFTs to EVM
+    ///
+    access(self)
+    fun handleEVMNativeCrossVMNFTToEVM(
+        token: @{NonFungibleToken.NFT},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        if !FlowEVMBridgeUtils.isCadenceNative(type: token.getType()) {
+            // Bridge-defined token means this is a bridged token - passthrough to appropriate handler method
+            return self.handleUpdatedBridgedNFTToEVM(token: <-token, to: to, feeProvider: feeProvider)
+        }
+        let type = token.getType()
+        let id = UInt256(token.id)
+        let customERC721 = FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: token.getType())!
+
+        // Escrow the NFT & charge the bridge fee
+        self.escrowNFTAndWithdrawFee(token: <-token, from: feeProvider)
+
+        // Transfer the ERC721 from escrow to the named recipient
+        FlowEVMBridgeUtils.mustSafeTransferERC721(erc721Address: customERC721, to: to, id: id)
+    }
+
+    /// Handler to move NFTs to EVM that were once bridge-defined but were later updated to a registered custom
+    /// cross-VM implementation
+    ///
+    access(self)
+    fun handleUpdatedBridgedNFTToEVM(
+        token: @{NonFungibleToken.NFT},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        pre {
+            !FlowEVMBridgeUtils.isCadenceNative(type: token.getType()):
+            "Expected a bridge-defined NFT but was provided NFT of type \(token.getType().identifier)"
+        }
+        let bridgedAssociation = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: token.getType())!
+        let updatedCadenceAssociation = FlowEVMBridgeCustomAssociations.getTypeAssociated(with: bridgedAssociation)
+            ?? panic("Could not find a custom cross-VM association for NFT \(token.getType().identifier) #\(token.id). The handleUpdatedBridgedNFTToEVM route is intended for bridged Cadence NFTs associated with  ERC721 contracts that have registered as a custom cross-VM NFT collection.")
+
+        // Ensure the updated/custom type is not paused - the top-level pause check only covers the
+        // caller-supplied bridge-defined type, so we must re-check here after resolving the migration target
+        assert(FlowEVMBridgeConfig.isTypePaused(updatedCadenceAssociation) == false,
+            message: "Bridging is currently paused for type \(updatedCadenceAssociation.identifier)")
+
+        // The force-casts to CrossVMNFT.EVMNFT below are safe: this handler is only reached when the token is a
+        // bridge-defined NFT (pre-condition enforces !isCadenceNative). All bridge-defined NFTs are deployed from
+        // the bridge's template contract, which unconditionally implements CrossVMNFT.EVMNFT. No user-controlled
+        // contract can produce a bridge-defined type, so these casts cannot fail in practice.
+        let tokenRef = (&token as &{NonFungibleToken.NFT}) as! &{CrossVMNFT.EVMNFT}
+        let evmID = tokenRef.evmID
+        let bridgedToken <- token as! @{CrossVMNFT.EVMNFT}
+        emit BridgedNFTBurned(
+            type: bridgedToken.getType().identifier,
+            id: bridgedToken.id,
+            evmID: bridgedToken.evmID,
+            uuid: bridgedToken.uuid,
+            erc721Address: bridgedAssociation.toString()
+        )
+        Burner.burn(<-bridgedToken)
+        // No bridge fee is charged here. The bridge burns the legacy Cadence NFT and releases the ERC721 from
+        // EVM-side escrow — no new assets are added to bridge storage, so no storage cost is incurred.
+        // Transfer the ERC721 from escrow to the named recipient
+        FlowEVMBridgeUtils.mustSafeTransferERC721(erc721Address: bridgedAssociation, to: to, id: evmID)
+    }
+
+    /// Handle permissionlessly onboarded NFTs where the bridge deployed and manages the non-native contract
+    ///
+    access(self)
+    fun handleDefaultNFTFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        id: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (EVM.EVMAddress): EVM.ResultDecoded
+    ): @{NonFungibleToken.NFT} {
+        /* Provision fee */
+        //
+        // Withdraw from feeProvider and deposit to self
+        let feeAmount = FlowEVMBridgeUtils.calculateBridgeFee(bytes: 0)
+        FlowEVMBridgeUtils.depositFee(feeProvider, feeAmount: feeAmount)
+
+        /* Execute escrow transfer */
+        //
+        // Get the EVMAddress of the ERC721 contract associated with the type
+        let associatedAddress = FlowEVMBridgeConfig.getEVMAddressAssociated(with: type)
+            ?? panic("No EVMAddress found for token type")
+        // Execute the transfer call and make needed state assertions to confirm escrow from named owner
+        FlowEVMBridgeUtils.mustEscrowERC721(
+            owner: owner,
+            id: id,
+            erc721Address: associatedAddress,
+            protectedTransferCall: protectedTransferCall
+        )
+
+        /* Gather identifying info */
+        //
+        // Derive the defining Cadence contract name & address & attempt to borrow it as IEVMBridgeNFTMinter
+        let contractName = FlowEVMBridgeUtils.getContractName(fromType: type)!
+        let contractAddress = FlowEVMBridgeUtils.getContractAddress(fromType: type)!
+        let nftContract = getAccount(contractAddress).contracts.borrow<&{IEVMBridgeNFTMinter}>(name: contractName)
+        // Get the token URI from the ERC721 contract
+        let uri = FlowEVMBridgeUtils.getTokenURI(evmContractAddress: associatedAddress, id: id)
+
+        /* Unlock escrowed NFTs */
+        //
+        // If the NFT is currently locked, unlock and return
+        if let cadenceID = FlowEVMBridgeNFTEscrow.getLockedCadenceID(type: type, evmID: id) {
+            let nft <- FlowEVMBridgeNFTEscrow.unlockNFT(type: type, id: cadenceID)
+
+            // If the NFT is bridge-defined, update the URI from the source ERC721 contract
+            if self.account.address == FlowEVMBridgeUtils.getContractAddress(fromType: type) {
+                nftContract!.updateTokenURI(evmID: id, newURI: uri)
+            }
+
+            return <-nft
+        }
+
+        /* Mint bridge-defined NFT */
+        //
+        // Ensure the NFT is bridge-defined
+        assert(self.account.address == contractAddress, message: "Unexpected error bridging NFT from EVM")
+
+        // We expect the NFT to be minted in Cadence as it is bridge-defined
+        let nft <- nftContract!.mintNFT(id: id, tokenURI: uri)
+        return <-nft
+    }
+
+    /// Handler to move registered cross-VM NFTs from EVM
+    ///
+    access(self)
+    fun handleCrossVMNFTFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        id: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (EVM.EVMAddress): EVM.ResultDecoded
+    ): @{NonFungibleToken.NFT} {
+        let evmPointer = FlowEVMBridgeCustomAssociations.getEVMPointerAsRegistered(forType: type)
+            ?? panic("Could not find custom association for cross-VM NFT \(type.identifier) with id \(id). Ensure this NFT has been registered as a cross-VM.")
+        if evmPointer.nativeVM == CrossVMMetadataViews.VM.Cadence {
+            return <- self.handleCadenceNativeCrossVMNFTFromEVM(
+                owner: owner,
+                type: type,
+                id: id,
+                feeProvider: feeProvider,
+                protectedTransferCall: protectedTransferCall
+            )
+        } else { // EVM-native case as there are only two possible VMs
+            return <- self.handleEVMNativeCrossVMNFTFromEVM(
+                owner: owner,
+                type: type,
+                id: id,
+                feeProvider: feeProvider,
+                protectedTransferCall: protectedTransferCall
+            )
+        }
+    }
+
+    /// Handler to move registered Cadence-native cross-VM NFTs from EVM
+    ///
+    access(self)
+    fun handleCadenceNativeCrossVMNFTFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        id: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (EVM.EVMAddress): EVM.ResultDecoded
+    ): @{NonFungibleToken.NFT} {
+        pre {
+            FlowEVMBridgeUtils.isCadenceNative(type: type):
+            "Attempting to move bridge-defined NFT type \(type.identifier) from EVM as Cadence-native via handleCadenceNativeCrossVMNFTFromEVM"
+        }
+        let configInfo = FlowEVMBridgeCustomAssociations.getCustomConfigInfo(forType: type)!
+        let customERC721 = configInfo.evmPointer.evmContractAddress
+        let bridgedAssociation = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: type)
+        let bridgedTokenExists = bridgedAssociation != nil ? FlowEVMBridgeUtils.erc721Exists(erc721Address: bridgedAssociation!, id: id) : false
+        if configInfo.updatedFromBridged && bridgedTokenExists {
+            let bridgedTokenOwner = FlowEVMBridgeUtils.ownerOf(id: id, evmContractAddress: bridgedAssociation!)!
+            if bridgedTokenOwner.equals(owner) {
+                FlowEVMBridgeUtils.mustEscrowERC721(
+                    owner: owner,
+                    id: id,
+                    erc721Address: bridgedAssociation!,
+                    protectedTransferCall: protectedTransferCall
+                )
+            } else if bridgedTokenOwner.equals(customERC721) {
+                // Bridged token owned by custom ERC721 - treat as OpenZeppelin's ERC721Wrapper, escrow & unwrap
+                FlowEVMBridgeUtils.mustEscrowERC721(
+                    owner: owner,
+                    id: id,
+                    erc721Address: customERC721,
+                    protectedTransferCall: protectedTransferCall
+                )
+                FlowEVMBridgeUtils.mustUnwrapERC721(
+                    id: id,
+                    erc721WrapperAddress: customERC721,
+                    underlyingEVMAddress: bridgedAssociation!
+                )
+            } else {
+                // Bridged token not wrapped nor owned by caller - could not determine owner
+                panic("Bridged ERC721 \(bridgedAssociation!.toString()) ID \(id) still exists after \(type.identifier) was updated to associate with ERC721 \(customERC721.toString()), but the bridged token is neither wrapped nor owned by caller \(owner.toString()). Could not determine owner.")
+            }
+            // Burn the bridged ERC721, taking the bridged representation out of circulation in favor of custom ERC721
+            FlowEVMBridgeUtils.mustBurnERC721(erc721Address: bridgedAssociation!, id: id)
+        } else {
+            FlowEVMBridgeUtils.mustEscrowERC721(
+                owner: owner,
+                id: id,
+                erc721Address: customERC721,
+                protectedTransferCall: protectedTransferCall
+            )
+        }
+        // No bridge fee is charged here. The bridge is releasing a Cadence-native NFT from existing escrow — the
+        // storage cost was already accounted for when the NFT was escrowed on the ToEVM path. Unlocking reduces
+        // bridge storage rather than increasing it, so no new fee is warranted.
+        // Cadence-native NFTs must be in escrow, so unlock & return
+        let lockedCadenceID = FlowEVMBridgeNFTEscrow.getLockedCadenceID(type: type, evmID: id)
+            ?? panic("NFT of type \(type.identifier) with EVM ID \(id) is not in escrow — cannot bridge from EVM")
+        return <-FlowEVMBridgeNFTEscrow.unlockNFT(type: type, id: lockedCadenceID)
+    }
+
+    /// Handler to move registered cross-VM EVM-native NFTs from EVM
+    ///
+    /// Note on `_type` vs `type`: this handler is only reached via `handleCrossVMNFTFromEVM`, which is dispatched
+    /// when `customAssocByType != nil` — meaning the caller-supplied `type` is always the custom cross-VM type,
+    /// not a legacy bridge-defined type. Therefore `isCadenceNative(type)` is always true for this handler, the
+    /// `if !isCadenceNative` branch below is never entered, and `_type` is never reassigned away from `type`.
+    /// The `isLocked` check and the `unlockNFT`/`fulfillNFTFromEVM` calls therefore always use the same type.
+    ///
+    access(self)
+    fun handleEVMNativeCrossVMNFTFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        id: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (EVM.EVMAddress): EVM.ResultDecoded
+    ): @{NonFungibleToken.NFT} {
+        pre {
+            id <= UInt256(UInt64.max):
+            "NFT ID \(id) is greater than the maximum Cadence ID \(UInt64.max) - cannot fulfill this NFT from EVM"
+        }
+        var _type = type
+        let erc721Address = FlowEVMBridgeConfig.getEVMAddressAssociated(with: type)!
+
+        // Burn if NFT is found to be bridge-defined as it's to be replaced by the registered custom cross-VM NFT
+        if !FlowEVMBridgeUtils.isCadenceNative(type: type) {
+            // Find and assign the updated custom Cadence NFT Type associated with the EVM-native ERC721
+            _type = FlowEVMBridgeConfig.getTypeAssociated(with: erc721Address)!
+
+            // Burn the bridged NFT token if it's locked
+            if let cadenceID = FlowEVMBridgeNFTEscrow.getLockedCadenceID(type: type, evmID: id) {
+                let bridgedToken <- FlowEVMBridgeNFTEscrow.unlockNFT(type: type, id: cadenceID) as! @{CrossVMNFT.EVMNFT}
+                emit BridgedNFTBurned(
+                    type: bridgedToken.getType().identifier,
+                    id: bridgedToken.id,
+                    evmID: bridgedToken.evmID,
+                    uuid: bridgedToken.uuid,
+                    erc721Address: erc721Address.toString()
+                )
+                Burner.burn(<-bridgedToken)
+            }
+        }
+
+        FlowEVMBridgeUtils.mustEscrowERC721(owner: owner, id: id, erc721Address: erc721Address, protectedTransferCall: protectedTransferCall)
+
+        // No bridge fee is charged here. EVM-native NFTs are fulfilled either by unlocking from existing Cadence
+        // escrow (reducing bridge storage) or by minting via the project-provided NFTFulfillmentMinter (no bridge
+        // storage involved). In neither case does the bridge account incur a new storage cost.
+        if FlowEVMBridgeNFTEscrow.isLocked(type: type, id: UInt64(id)) {
+            // Unlock the NFT from escrow
+            return <-FlowEVMBridgeNFTEscrow.unlockNFT(type: _type, id: UInt64(id))
+        } else {
+            // Otherwise, fulfill via configured NFTFulfillmentMinter
+            return <- FlowEVMBridgeCustomAssociations.fulfillNFTFromEVM(forType: _type, id: id)
+        }
+    }
+
+    access(self)
+    fun handleUpdatedBridgedNFTFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        id: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (EVM.EVMAddress): EVM.ResultDecoded
+    ): @{NonFungibleToken.NFT} {
+        pre {
+            !FlowEVMBridgeUtils.isCadenceNative(type: type): // expect this type to be bridge-defined
+            "Expected a bridge-defined NFT but was provided NFT of type \(type.identifier)"
+            id < UInt256(UInt64.max):
+            "Requested ID \(id) exceeds UIn64.max - Cross-VM NFT IDs must be within UInt64 range across Cadence & EVM implementations"
+        }
+        // Assign the legacy and custom associations
+        let bridgedAssoc = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: type)!
+        let updatedTypeAssoc = FlowEVMBridgeConfig.getTypeAssociated(with: bridgedAssoc)!
+
+        // Ensure the updated/custom type is not paused - the top-level pause check only covers the
+        // caller-supplied legacy type, so we must re-check here after resolving the migration target
+        assert(FlowEVMBridgeConfig.isTypePaused(updatedTypeAssoc) == false,
+            message: "Bridging is currently paused for type \(updatedTypeAssoc.identifier)")
+
+        // Confirm custom association is EVM-native
+        let configInfo = FlowEVMBridgeCustomAssociations.getCustomConfigInfo(forType: updatedTypeAssoc)!
+        assert(configInfo.evmPointer.nativeVM == CrossVMMetadataViews.VM.EVM,
+            message: "Expected native VM for ERC721 \(bridgedAssoc.toString()) associated with NFT type \(type.identifier) to be EVM-native")
+
+        FlowEVMBridgeUtils.mustEscrowERC721(owner: owner, id: id, erc721Address: bridgedAssoc, protectedTransferCall: protectedTransferCall)
+
+        // Check if originally associated bridged token is in escrow, burning if so
+        if let lockedCadenceID = FlowEVMBridgeNFTEscrow.getLockedCadenceID(type: type, evmID: id) {
+            let bridgedToken <- FlowEVMBridgeNFTEscrow.unlockNFT(type: type, id: lockedCadenceID) as! @{CrossVMNFT.EVMNFT}
+            emit BridgedNFTBurned(
+                type: bridgedToken.getType().identifier,
+                id: bridgedToken.id,
+                evmID: bridgedToken.evmID,
+                uuid: bridgedToken.uuid,
+                erc721Address: bridgedAssoc.toString()
+            )
+            Burner.burn(<-bridgedToken)
+        }
+        // No bridge fee is charged here. The legacy bridge-defined NFT (if present in escrow) is burned, and the
+        // custom type NFT is either unlocked from existing escrow or minted via the project's NFTFulfillmentMinter.
+        // In all cases the bridge is releasing or burning assets rather than storing new ones, so no storage cost
+        // is incurred and no fee is warranted.
+        // Either unlock if locked or fulfill via configured NFTFulfillmentMinter
+        if FlowEVMBridgeNFTEscrow.isLocked(type: updatedTypeAssoc, id: UInt64(id)) {
+            return <- FlowEVMBridgeNFTEscrow.unlockNFT(type: updatedTypeAssoc, id: UInt64(id))
+        } else {
+            return <- FlowEVMBridgeCustomAssociations.fulfillNFTFromEVM(forType: updatedTypeAssoc, id: id)
+        }
+    }
+}

--- a/contracts/external/FlowEVMBridgeAccessor.cdc
+++ b/contracts/external/FlowEVMBridgeAccessor.cdc
@@ -1,0 +1,207 @@
+import "NonFungibleToken"
+import "FungibleToken"
+import "FlowToken"
+
+import "EVM"
+
+import "FlowEVMBridgeConfig"
+import "FlowEVMBridge"
+import "FlowEVMBridgeUtils"
+
+/// This contract defines a mechanism for routing bridge requests from the EVM contract to the Flow-EVM bridge contract
+///
+access(all)
+contract FlowEVMBridgeAccessor {
+
+    access(all) let StoragePath: StoragePath
+
+    /// BridgeAccessor implementation used by the EVM contract to route bridge calls from COA resources
+    ///
+    access(all)
+    resource BridgeAccessor : EVM.BridgeAccessor {
+
+        /// Passes along the bridge request to dedicated bridge contract
+        ///
+        /// @param nft: The NFT to be bridged to EVM
+        /// @param to: The address of the EVM account to receive the bridged NFT
+        /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+        ///
+        access(EVM.Bridge)
+        fun depositNFT(
+            nft: @{NonFungibleToken.NFT},
+            to: EVM.EVMAddress,
+            feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+        ) {
+            FlowEVMBridge.bridgeNFTToEVM(token: <-nft, to: to, feeProvider: feeProvider)
+        }
+
+        /// Passes along the bridge request to the dedicated bridge contract, returning the bridged NFT
+        ///
+        /// @param caller: A reference to the COA which currently owns the NFT in EVM
+        /// @param type: The Cadence type of the NFT to be bridged from EVM
+        /// @param id: The ID of the NFT to be bridged from EVM
+        /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+        ///
+        /// @return The bridged NFT
+        ///
+        access(EVM.Bridge)
+        fun withdrawNFT(
+            caller: auth(EVM.Call) &EVM.CadenceOwnedAccount,
+            type: Type,
+            id: UInt256,
+            feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+        ): @{NonFungibleToken.NFT} {
+            // Define a callback function, enabling the bridge to act on the ephemeral COA reference in scope
+            var executed = false
+            fun callback(target: EVM.EVMAddress): EVM.ResultDecoded {
+                pre {
+                    !executed: "Callback can only be executed once"
+                    FlowEVMBridge.getAssociatedEVMAddress(with: type) ?? FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: type) != nil:
+                    "Could not find EVM association for NFT Type \(type.identifier) - ensure the NFT has been onboarded to the bridge & try again"
+                }
+                post {
+                    executed: "Callback must be executed"
+                }
+                // Ensure the call is to an EVM contract known to be associated with the NFT Type as registered with
+                // the VM Bridge
+                let callAllowed = FlowEVMBridgeAccessor.isValidEVMTarget(forType: type, target: target)
+                assert(callAllowed,
+                    message: "Target EVM contract \(target.toString()) is not association with NFT Type \(type.identifier) - COA `safeTransferFrom` callback rejected")
+
+                executed = true
+                return caller.callWithSigAndArgs(
+                    to: target,
+                    signature: "safeTransferFrom(address,address,uint256)",
+                    args: [caller.address(), FlowEVMBridge.getBridgeCOAEVMAddress(), id],
+                    gasLimit: FlowEVMBridgeConfig.gasLimit,
+                    value: 0,
+                    resultTypes: nil
+                )
+            }
+            // Execute the bridge request
+            return <- FlowEVMBridge.bridgeNFTFromEVM(
+                owner: caller.address(),
+                type: type,
+                id: id,
+                feeProvider: feeProvider,
+                protectedTransferCall: callback
+            )
+        }
+
+        /// Passes along the bridge request to dedicated bridge contract
+        ///
+        /// @param vault: The fungible token vault to be bridged to EVM
+        /// @param to: The address of the EVM account to receive the bridged tokens
+        /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+        ///
+        access(EVM.Bridge)
+        fun depositTokens(
+            vault: @{FungibleToken.Vault},
+            to: EVM.EVMAddress,
+            feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+        ) {
+            FlowEVMBridge.bridgeTokensToEVM(vault: <-vault, to: to, feeProvider: feeProvider)
+        }
+
+        /// Passes along the bridge request to the dedicated bridge contract, returning the bridged FungibleToken
+        ///
+        /// @param caller: A reference to the COA which currently owns the tokens in EVM
+        /// @param type: The Cadence type of the fungible token vault to be bridged from EVM
+        /// @param amount: The amount of tokens to be bridged
+        /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+        ///
+        /// @return The bridged FungibleToken Vault
+        ///
+        access(EVM.Bridge)
+        fun withdrawTokens(
+            caller: auth(EVM.Call) &EVM.CadenceOwnedAccount,
+            type: Type,
+            amount: UInt256,
+            feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+        ): @{FungibleToken.Vault} {
+            // Resolve the EVM address associated with the token type
+            let associatedEVMAddress = FlowEVMBridge.getAssociatedEVMAddress(with: type)
+                ?? panic("No EVM address associated with type")
+            // Round the requested ERC20 amount down to the maximum precision representable by UFix64 to ensure the
+            // amount escrowed on the EVM side matches exactly what will be minted or unlocked on the Cadence side,
+            // preventing sub-UFix64-precision "dust" from being permanently locked in escrow.
+            let roundedAmount = FlowEVMBridgeUtils.castERC20AmountToCadencePrecision(amount, erc20Address: associatedEVMAddress)
+            // Define a callback function, enabling the bridge to act on the ephemeral COA reference in scope
+            var executed = false
+            fun callback(): EVM.ResultDecoded {
+                pre {
+                    !executed: "Callback can only be executed once"
+                }
+                post {
+                    executed: "Callback must be executed"
+                }
+                executed = true
+                return caller.callWithSigAndArgs(
+                    to: associatedEVMAddress,
+                    signature: "transfer(address,uint256)",
+                    args: [FlowEVMBridge.getBridgeCOAEVMAddress(), roundedAmount],
+                    gasLimit: FlowEVMBridgeConfig.gasLimit,
+                    value: 0,
+                    resultTypes: nil
+                )
+            }
+            // Execute the bridge request
+            return <- FlowEVMBridge.bridgeTokensFromEVM(
+                owner: caller.address(),
+                type: type,
+                amount: roundedAmount,
+                feeProvider: feeProvider,
+                protectedTransferCall: callback
+            )
+        }
+
+        /// Returns a BridgeRouter resource so a Capability on this BridgeAccessor can be stored in the BridgeRouter
+        ///
+        access(EVM.Bridge) fun createBridgeRouter(): @BridgeRouter {
+            return <-create BridgeRouter()
+        }
+    }
+
+    /// BridgeRouter implementation used by the EVM contract to capture a BridgeAccessor Capability and route bridge
+    /// calls from COA resources to the FlowEVMBridge contract
+    ///
+    access(all) resource BridgeRouter : EVM.BridgeRouter {
+        /// Capability to the BridgeAccessor resource, initialized to nil
+        access(self) var bridgeAccessorCap: Capability<auth(EVM.Bridge) &{EVM.BridgeAccessor}>?
+
+        init() {
+            self.bridgeAccessorCap = nil
+        }
+
+        /// Returns an EVM.Bridge entitled reference to the underlying BridgeAccessor resource
+        ///
+        access(EVM.Bridge) view fun borrowBridgeAccessor(): auth(EVM.Bridge) &{EVM.BridgeAccessor} {
+            let cap = self.bridgeAccessorCap ?? panic("BridgeAccessor Capabaility is not yet set")
+            return cap.borrow() ?? panic("Problem retrieving BridgeAccessor reference")
+        }
+
+        /// Sets the BridgeAccessor Capability in the BridgeRouter
+        access(EVM.Bridge) fun setBridgeAccessor(_ accessorCap: Capability<auth(EVM.Bridge) &{EVM.BridgeAccessor}>) {
+            self.bridgeAccessorCap = accessorCap
+        }
+    }
+
+    /// Assesses whether the EVM contract address is associated with the provided type based on bridge associations
+    ///
+    access(self)
+    fun isValidEVMTarget(forType: Type, target: EVM.EVMAddress): Bool {
+        let currentAssociation = FlowEVMBridge.getAssociatedEVMAddress(with: forType)
+        let bridgedAssociation = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: forType)
+        return currentAssociation?.equals(target) ?? false || bridgedAssociation?.equals(target) ?? false
+    }
+
+    init(publishToEVMAccount: Address) {
+        self.StoragePath = /storage/flowEVMBridgeAccessor
+        self.account.storage.save(
+            <-create BridgeAccessor(),
+            to: self.StoragePath
+        )
+        let cap = self.account.capabilities.storage.issue<auth(EVM.Bridge) &BridgeAccessor>(self.StoragePath)
+        self.account.inbox.publish(cap, name: "FlowEVMBridgeAccessor", recipient: publishToEVMAccount)
+    }
+}

--- a/contracts/external/FlowEVMBridgeConfig.cdc
+++ b/contracts/external/FlowEVMBridgeConfig.cdc
@@ -1,0 +1,689 @@
+import "EVM"
+import "NonFungibleToken"
+
+import "FlowEVMBridgeHandlerInterfaces"
+import "FlowEVMBridgeCustomAssociations"
+
+/// This contract is used to store configuration information shared by FlowEVMBridge contracts
+///
+access(all)
+contract FlowEVMBridgeConfig {
+
+    /******************
+        Entitlements
+    *******************/
+
+    access(all) entitlement Gas
+    access(all) entitlement Fee
+    access(all) entitlement Pause
+    access(all) entitlement Blocklist
+
+    /*************
+        Fields
+    **************/
+
+    /// Amount of FLOW paid to onboard a Type or EVMAddress to the bridge
+    access(all)
+    var onboardFee: UFix64
+    /// Flat rate fee for all bridge requests
+    access(all)
+    var baseFee: UFix64
+    /// Default ERC20.decimals() value
+    access(all)
+    let defaultDecimals: UInt8
+    /// The gas limit for all EVM calls related to bridge operations
+    access(all)
+    var gasLimit: UInt64
+    /// Flag enabling pausing of bridge operations
+    access(self)
+    var paused: Bool
+    /// Mapping of Type to its associated EVMAddress. The contained struct values also store the operational status of
+    /// the association, allowing for pausing of operations by Type
+    access(self) let registeredTypes: {Type: TypeEVMAssociation}
+    /// Reverse mapping of registeredTypes. Note the EVMAddress is stored as a hex string since the EVMAddress type
+    /// as of contract development is not a hashable or equatable type and making it so is not supported by Cadence
+    access(self)
+    let evmAddressHexToType: {String: Type}
+    /// Mapping of Type to its associated EVMAddress as relevant to the bridge
+    access(self)
+    let typeToTokenHandlers: @{Type: {FlowEVMBridgeHandlerInterfaces.TokenHandler}}
+
+    /********************
+        Path Constants
+    *********************/
+
+    /// StoragePath where bridge Cadence Owned Account is stored
+    access(all)
+    let coaStoragePath: StoragePath
+    /// StoragePath where bridge config Admin is stored
+    access(all)
+    let adminStoragePath: StoragePath
+    /// PublicPath where a public Capability on the bridge config Admin is exposed
+    access(all)
+    let adminPublicPath: PublicPath
+    /// StoragePath to store the Provider capability used as a bridge fee Provider
+    access(all)
+    let providerCapabilityStoragePath: StoragePath
+
+    /*************
+        Events
+    **************/
+
+    /// Emitted whenever the onboarding fee is updated
+    ///
+    access(all)
+    event BridgeFeeUpdated(old: UFix64, new: UFix64, isOnboarding: Bool)
+    /// Emitted whenever a TokenHandler is configured
+    ///
+    access(all)
+    event HandlerConfigured(targetType: String, targetEVMAddress: String?, isEnabled: Bool)
+    /// Emitted whenever the bridge is paused or unpaused globally - true for paused, false for unpaused
+    ///
+    access(all)
+    event BridgePauseStatusUpdated(paused: Bool)
+    /// Emitted whenever a specific asset is paused or unpaused - true for paused, false for unpaused
+    ///
+    access(all)
+    event AssetPauseStatusUpdated(paused: Bool, type: String, evmAddress: String)
+    /// Emitted whenever an association is updated
+    ///
+    access(all)
+    event AssociationUpdated(type: String, evmAddress: String)
+
+    /*************
+        Getters
+     *************/
+
+    /// Returns whether all bridge operations are currently paused or active
+    ///
+    access(all)
+    view fun isPaused(): Bool {
+        return self.paused
+    }
+
+    /// Returns whether operations for a given Type are paused.
+    ///
+    /// Note: the return type is `Bool?` for API compatibility, but this function currently always returns a
+    /// non-nil `Bool`. The three sub-expressions all produce concrete `Bool` values via nil-coalescing or direct
+    /// comparison. A `nil` return cannot occur under current logic. Call sites should use `== false` (rather than
+    /// `!= true`) so that a hypothetical future `nil` is treated conservatively as "paused" rather than
+    /// "not paused". The doc comment claim that `nil` means "not yet onboarded" does not reflect actual behavior
+    /// and is retained only for historical reference.
+    ///
+    access(all)
+    view fun isTypePaused(_ type: Type): Bool? {
+        // Paused if the type has a token handler & it's disabled, a custom config has been paused or the bridge config has been paused
+        return !(self.borrowTokenHandler(type)?.isEnabled() ?? true)
+            || FlowEVMBridgeCustomAssociations.isCustomConfigPaused(forType: type) ?? false
+            || self.registeredTypes[type]?.isPaused == true
+    }
+
+    /// Retrieves the EVMAddress associated with a given Type if it has been onboarded to the bridge
+    ///
+    access(all)
+    view fun getEVMAddressAssociated(with type: Type): EVM.EVMAddress? {
+        if self.typeHasTokenHandler(type) {
+            return self.borrowTokenHandler(type)!.getTargetEVMAddress()
+        }
+        let customAssociation = FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type)
+        return customAssociation ?? self.registeredTypes[type]?.evmAddress
+    }
+
+    /// Retrieves the type associated with a given EVMAddress if it has been onboarded to the bridge
+    ///
+    access(all)
+    view fun getTypeAssociated(with evmAddress: EVM.EVMAddress): Type? {
+        let evmAddressHex = evmAddress.toString()
+        let customAssociation = FlowEVMBridgeCustomAssociations.getTypeAssociated(with: evmAddress)
+        return customAssociation ?? self.evmAddressHexToType[evmAddressHex]
+    }
+
+    /// Returns whether the given EVMAddress is currently blocked from onboarding to the bridge
+    ///
+    access(all)
+    view fun isEVMAddressBlocked(_ evmAddress: EVM.EVMAddress): Bool {
+        return self.borrowEVMBlocklist().isBlocked(evmAddress)
+    }
+
+    /// Returns whether the given Cadence Type is currently blocked from onboarding to the bridge
+    ///
+    access(all)
+    view fun isCadenceTypeBlocked(_ type: Type): Bool {
+        return self.borrowCadenceBlocklist().isBlocked(type)
+    }
+
+    /// Returns the project-defined Type has been registered as a replacement for the originally bridge-defined asset
+    /// type. This would arise in the event an EVM-native project onboarded to the bridge via permissionless onboarding
+    /// & later registered their own Cadence NFT contract as associated with their ERC721 per FLIP-318 mechanisms.
+    /// If there is not a related custom cross-VM Type registered with the bridge, `nil` is returned.
+    ///
+    access(all)
+    view fun getUpdatedCustomCrossVMTypeForLegacyType(_ type: Type): Type? {
+        if !type.isSubtype(of: Type<@{NonFungibleToken.NFT}>()) || type.address! != self.account.address {
+            // only bridge-defined NFT Types can have an updated custom cross-VM implementation
+            return nil
+        }
+        if let legacyEVMAssoc = self.getLegacyEVMAddressAssociated(with: type) {
+            // return the new Type associated with the originally associated EVM contract address
+            return FlowEVMBridgeCustomAssociations.getTypeAssociated(with: legacyEVMAssoc)
+        }
+        return nil
+    }
+
+    /// Returns the bridge-defined Type that was originally associated with the related EVM contract given some
+    /// externally defined contract. This would arise in the event an EVM-native project onboarded to the bridge via
+    /// permissionless onboarding & later registered their own Cadence NFT contract as associated with their ERC721 per
+    /// FLIP-318 mechanisms. If there is not a related bridge-defined Type registered with the bridge, `nil` is returned.
+    ///
+    access(all)
+    view fun getLegacyTypeForCustomCrossVMType(_ type: Type): Type? {
+        if !type.isSubtype(of: Type<@{NonFungibleToken.NFT}>()) || type.address! == self.account.address {
+            // only externally-defined NFT Types can have an updated custom cross-VM implementation
+            return nil
+        }
+        if let customEVMAssoc = FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type ) {
+            // return the original bridged NFT Type associated with the custom cross-VM EVM contract address
+            return self.evmAddressHexToType[customEVMAssoc.toString()]
+        }
+        return nil
+    }
+
+    /// Returns the project-defined EVM contract address has been registered as a replacement for the originally bridge-
+    /// defined asset EVM contract. This would arise in the event an Cadence-native project onboarded to the bridge via
+    /// permissionless onboarding & later registered their own EVM contract as associated with their Cadence NFT per
+    /// FLIP-318 mechanisms. If there is not a related custom cross-VM EVM contract registered with the bridge, `nil` is
+    /// returned.
+    ///
+    access(all)
+    view fun getUpdatedCustomCrossVMEVMAddressForLegacyEVMAddress(_ evmAddress: EVM.EVMAddress): EVM.EVMAddress? {
+        if let legacyType = self.getLegacyTypeAssociated(with: evmAddress) {
+            // return the new EVM address associated with the originally associated Type
+            return FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: legacyType)
+        }
+        return nil
+    }
+
+    /// Returns the bridge-defined EVM contract address that was originally associated with the related Cadence NFT
+    /// given some externally defined contract. This would arise in the event a Cadence-native project onboarded to the
+    /// bridge via permissionless onboarding & later registered their own EVM contract as associated with their
+    /// Cadence NFT per FLIP-318 mechanisms. If there is not a related bridge-defined EVM contract registered with the
+    /// bridge, `nil` is returned.
+    ///
+    access(all)
+    view fun getLegacyEVMAddressForCustomCrossVMAddress(_ evmAddress: EVM.EVMAddress): EVM.EVMAddress? {
+        if let customType = FlowEVMBridgeCustomAssociations.getTypeAssociated(with: evmAddress) {
+            // return the original bridged NFT Type associated with the custom cross-VM EVM contract address
+            return self.registeredTypes[customType]?.evmAddress
+        }
+        return nil
+    }
+
+    /****************************
+        Bridge Account Methods
+     ****************************/
+
+    /// Returns whether the given Type has a TokenHandler configured
+    ///
+    access(account)
+    view fun typeHasTokenHandler(_ type: Type): Bool {
+        return self.typeToTokenHandlers[type] != nil
+    }
+
+    /// Returns whether the given EVMAddress has a TokenHandler configured
+    ///
+    access(account)
+    view fun evmAddressHasTokenHandler(_ evmAddress: EVM.EVMAddress): Bool {
+        let associatedType = self.getTypeAssociated(with: evmAddress)
+        return associatedType != nil ? self.typeHasTokenHandler(associatedType!) : false
+    }
+
+    /// Returns the Type associated with the provided EVM contract address if the association was established via
+    /// the permissionless onboarding path
+    ///
+    access(account)
+    view fun getLegacyTypeAssociated(with evmAddress: EVM.EVMAddress): Type? {
+        return self.evmAddressHexToType[evmAddress.toString()] ?? nil
+    }
+
+    /// Returns the EVM contract address associated with the provided Type if the association was established via
+    /// the permissionless onboarding path
+    ///
+    access(account)
+    view fun getLegacyEVMAddressAssociated(with type: Type): EVM.EVMAddress? {
+        if self.typeHasTokenHandler(type) {
+            return self.borrowTokenHandler(type)!.getTargetEVMAddress()
+        }
+        return self.registeredTypes[type]?.evmAddress ?? nil
+    }
+
+    /// Enables bridge contracts to add new associations between types and EVM addresses
+    ///
+    access(account)
+    fun associateType(_ type: Type, with evmAddress: EVM.EVMAddress) {
+        pre {
+            self.getEVMAddressAssociated(with: type) == nil:
+            "Type ".concat(type.identifier).concat(" already associated with an EVMAddress ")
+                .concat(self.registeredTypes[type]!.evmAddress.toString())
+            self.getTypeAssociated(with: evmAddress) == nil:
+            "EVMAddress ".concat(evmAddress.toString()).concat(" already associated with Type ")
+                .concat(self.evmAddressHexToType[evmAddress.toString()]!.identifier)
+        }
+        self.registeredTypes[type] = TypeEVMAssociation(associated: evmAddress)
+        let evmAddressHex = evmAddress.toString()
+        self.evmAddressHexToType[evmAddressHex] = type
+
+        emit AssociationUpdated(type: type.identifier, evmAddress: evmAddressHex)
+    }
+
+    /// Adds a TokenHandler to the bridge configuration
+    ///
+    access(account)
+    fun addTokenHandler(_ handler: @{FlowEVMBridgeHandlerInterfaces.TokenHandler}) {
+        pre {
+            handler.getTargetType() != nil: "Cannot configure Handler without a target Cadence Type set"
+            self.getEVMAddressAssociated(with: handler.getTargetType()!) == nil:
+                "Cannot configure Handler for Type that has already been onboarded to the bridge"
+            self.borrowTokenHandler(handler.getTargetType()!) == nil:
+                "Cannot configure Handler for Type that already has a Handler configured"
+        }
+        let type = handler.getTargetType()!
+        var targetEVMAddressHex: String? = nil
+        if let targetEVMAddress = handler.getTargetEVMAddress() {
+            targetEVMAddressHex = targetEVMAddress.toString()
+
+            let associatedType = self.getTypeAssociated(with: targetEVMAddress)
+            assert(
+                associatedType == nil,
+                message: "Handler target EVMAddress is already associated with a different Type"
+            )
+            self.associateType(type, with: targetEVMAddress)
+        }
+
+        emit HandlerConfigured(
+            targetType: type.identifier,
+            targetEVMAddress: targetEVMAddressHex,
+            isEnabled: handler.isEnabled()
+        )
+
+        self.typeToTokenHandlers[type] <-! handler
+    }
+
+    /// Returns an unentitled reference to the TokenHandler associated with the given Type
+    ///
+    access(account)
+    view fun borrowTokenHandler(
+        _ type: Type
+    ): &{FlowEVMBridgeHandlerInterfaces.TokenHandler}? {
+        return &self.typeToTokenHandlers[type]
+    }
+
+    /// Returns an entitled reference to the TokenHandler associated with the given Type
+    ///
+    access(self)
+    view fun borrowTokenHandlerAdmin(
+        _ type: Type
+    ): auth(FlowEVMBridgeHandlerInterfaces.Admin) &{FlowEVMBridgeHandlerInterfaces.TokenHandler}? {
+        return &self.typeToTokenHandlers[type]
+    }
+
+    /// Returns an entitled reference to the bridge EVMBlocklist
+    ///
+    access(self)
+    view fun borrowEVMBlocklist(): auth(Blocklist) &EVMBlocklist {
+        return self.account.storage.borrow<auth(Blocklist) &EVMBlocklist>(from: /storage/evmBlocklist)
+            ?? panic("Missing or mis-typed EVMBlocklist in storage")
+    }
+
+    /// Returns an entitled reference to the bridge CadenceBlocklist
+    ///
+    access(self)
+    view fun borrowCadenceBlocklist(): auth(Blocklist) &CadenceBlocklist {
+        return self.account.storage.borrow<auth(Blocklist) &CadenceBlocklist>(from: /storage/cadenceBlocklist)
+            ?? panic("Missing or mis-typed CadenceBlocklist in storage")
+    }
+
+    /// Sets the pause status of a given type, reverting if the type has no associated EVM address as either bridge-
+    /// defined or registered as a custom cross-VM association
+    ///
+    access(self)
+    fun updatePauseStatus(_ type: Type, pause: Bool) {
+        var evmAddress = ""
+        var updated = false
+        if let customAssoc = FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type) {
+            updated = FlowEVMBridgeCustomAssociations.isCustomConfigPaused(forType: type)! != pause
+            // Called methods no-op internally, so check for status update is skipped here
+            pause ? FlowEVMBridgeCustomAssociations.pauseCustomConfig(forType: type)
+                : FlowEVMBridgeCustomAssociations.unpauseCustomConfig(forType: type)
+            // Assign the EVM address based on the CustomConfig value
+            evmAddress = customAssoc.toString()
+        }
+        if let bridgedAssoc = &FlowEVMBridgeConfig.registeredTypes[type] as &TypeEVMAssociation? {
+            if evmAddress.length == 0 {
+                // Assign as bridge association only if custom association does not exist
+                evmAddress = bridgedAssoc.evmAddress.toString()
+            }
+            // No-op if already meets pause status, otherwise update as specified
+            if (pause && !bridgedAssoc.isPaused) || (!pause && bridgedAssoc.isPaused) {
+                updated = true
+                pause ? bridgedAssoc.pause() : bridgedAssoc.unpause()
+            }
+        }
+        assert(evmAddress.length > 0,
+            message: "There was no association found for type \(type.identifier). To block the type from onboarding, use the CadenceBlocklist.")
+        if updated { emit AssetPauseStatusUpdated(paused: pause, type: type.identifier, evmAddress: evmAddress) }
+    }
+
+    /*****************
+        Constructs
+     *****************/
+
+    /// Entry in the registeredTypes mapping, associating a Type with an EVMAddress and its operational status. Since
+    /// the registeredTypes mapping is indexed on Type, this struct does not additionally store the Type to reduce
+    /// redundant storage.
+    ///
+    access(all) struct TypeEVMAssociation {
+        /// The EVMAddress associated with the Type
+        access(all) let evmAddress: EVM.EVMAddress
+        /// Flag indicating whether operations for the associated Type are paused
+        access(all) var isPaused: Bool
+
+        init(associated evmAddress: EVM.EVMAddress) {
+            self.evmAddress = evmAddress
+            self.isPaused = false
+        }
+
+        /// Pauses operations for this association
+        ///
+        access(contract) fun pause() {
+            self.isPaused = true
+        }
+
+        /// Unpauses operations for this association
+        ///
+        access(contract) fun unpause() {
+            self.isPaused = false
+        }
+    }
+
+    /// EVMBlocklist resource stores a mapping of EVM addresses that are blocked from onboarding to the bridge
+    ///
+    access(all) resource EVMBlocklist {
+        /// Mapping of serialized EVM addresses to their blocked status
+        ///
+        access(all) let blocklist: {String: Bool}
+
+        init() {
+            self.blocklist = {}
+        }
+
+        /// Returns whether the given EVM address is blocked from onboarding to the bridge
+        ///
+        access(all) view fun isBlocked(_ evmAddress: EVM.EVMAddress): Bool {
+            return self.blocklist[evmAddress.toString()] ?? false
+        }
+
+        /// Blocks the given EVM address from onboarding to the bridge
+        ///
+        access(Blocklist) fun block(_ evmAddress: EVM.EVMAddress) {
+            self.blocklist[evmAddress.toString()] = true
+        }
+
+        /// Removes the given EVM address from the blocklist
+        ///
+        access(Blocklist) fun unblock(_ evmAddress: EVM.EVMAddress) {
+            self.blocklist.remove(key: evmAddress.toString())
+        }
+    }
+
+    /// CadenceBlocklist resource stores a mapping of Cadence Types that are blocked from onboarding to the bridge
+    ///
+    access(all) resource CadenceBlocklist {
+        /// Mapping of serialized Cadence Type to their blocked status
+        ///
+        access(all) let blocklist: {Type: Bool}
+
+        init() {
+            self.blocklist = {}
+        }
+
+        /// Returns whether the given Type is blocked from onboarding to the bridge
+        ///
+        access(all) view fun isBlocked(_ type: Type): Bool {
+            return self.blocklist[type] ?? false
+        }
+
+        /// Blocks the given Type from onboarding to the bridge
+        ///
+        access(Blocklist) fun block(_ type: Type) {
+            self.blocklist[type] = true
+        }
+
+        /// Removes the given type from the blocklist
+        ///
+        access(Blocklist) fun unblock(_ type: Type) {
+            self.blocklist.remove(key: type)
+        }
+    }
+
+    /*****************
+        Config Admin
+     *****************/
+
+    /// Admin resource enables updates to the bridge fees
+    ///
+    access(all)
+    resource Admin {
+
+        /// Sets the TokenMinter for the given Type. If a TokenHandler does not exist for the given Type, the operation
+        /// reverts. The provided minter must be of the expected type for the TokenHandler and the handler cannot have
+        /// a minter already set.
+        ///
+        /// @param targetType: Cadence type indexing the relevant TokenHandler
+        /// @param minter: TokenMinter minter to set for the TokenHandler
+        ///
+        access(all)
+        fun setTokenHandlerMinter(targetType: Type, minter: @{FlowEVMBridgeHandlerInterfaces.TokenMinter}) {
+            pre {
+                FlowEVMBridgeConfig.typeHasTokenHandler(targetType):
+                    "Cannot set minter for Type that does not have a TokenHandler configured"
+                FlowEVMBridgeConfig.borrowTokenHandlerAdmin(targetType) != nil:
+                    "No handler found for target Type"
+                FlowEVMBridgeConfig.borrowTokenHandlerAdmin(targetType)!.getExpectedMinterType() == minter.getType():
+                    "Invalid minter type"
+            }
+            FlowEVMBridgeConfig.borrowTokenHandlerAdmin(targetType)!.setMinter(<-minter)
+        }
+
+        /// Sets the gas limit for all EVM calls related to bridge operations
+        ///
+        /// @param lim the new gas limit
+        ///
+        access(Gas)
+        fun setGasLimit(_ limit: UInt64) {
+            FlowEVMBridgeConfig.gasLimit = limit
+        }
+
+        /// Updates the onboarding fee
+        ///
+        /// @param new: UFix64 - new onboarding fee
+        ///
+        /// @emits BridgeFeeUpdated with the old and new rates and isOnboarding set to true
+        ///
+        access(Fee)
+        fun updateOnboardingFee(_ new: UFix64) {
+            emit BridgeFeeUpdated(old: FlowEVMBridgeConfig.onboardFee, new: new, isOnboarding: true)
+            FlowEVMBridgeConfig.onboardFee = new
+        }
+
+        /// Updates the base fee
+        ///
+        /// @param new: UFix64 - new base fee
+        ///
+        /// @emits BridgeFeeUpdated with the old and new rates and isOnboarding set to false
+        ///
+        access(Fee)
+        fun updateBaseFee(_ new: UFix64) {
+            emit BridgeFeeUpdated(old: FlowEVMBridgeConfig.baseFee, new: new, isOnboarding: false)
+            FlowEVMBridgeConfig.baseFee = new
+        }
+
+        /// Pauses the bridge, preventing all bridge operations
+        ///
+        /// @emits BridgePauseStatusUpdated with true
+        ///
+        access(Pause)
+        fun pauseBridge() {
+            if FlowEVMBridgeConfig.isPaused() {
+                return
+            }
+            FlowEVMBridgeConfig.paused = true
+            emit BridgePauseStatusUpdated(paused: true)
+        }
+
+        /// Unpauses the bridge, allowing bridge operations to resume
+        ///
+        /// @emits BridgePauseStatusUpdated with true
+        ///
+        access(Pause)
+        fun unpauseBridge() {
+            if !FlowEVMBridgeConfig.isPaused() {
+                return
+            }
+            FlowEVMBridgeConfig.paused = false
+            emit BridgePauseStatusUpdated(paused: false)
+        }
+
+        /// Pauses all operations for a given asset type
+        ///
+        /// @param type: The Type for which to pause bridge operations
+        ///
+        /// @emits AssetPauseStatusUpdated with the pause status and serialized type & associated EVM address
+        ///
+        access(Pause)
+        fun pauseType(_ type: Type) {
+            pre {
+                FlowEVMBridgeConfig.getEVMAddressAssociated(with: type) != nil || FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type) != nil:
+                "Could not find a bridged or custom association for type \(type.identifier) - cannot pause a type without an association"
+            }
+            FlowEVMBridgeConfig.updatePauseStatus(type, pause: true)
+        }
+
+        /// Unpauses all operations for a given asset type
+        ///
+        /// @param type: The Type for which to unpause bridge operations
+        ///
+        /// @emits AssetPauseStatusUpdated with the pause status and serialized type & associated EVM address
+        ///
+        access(Pause)
+        fun unpauseType(_ type: Type) {
+            pre {
+                FlowEVMBridgeConfig.getEVMAddressAssociated(with: type) != nil || FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type) != nil:
+                "Could not find a bridged or custom association for type \(type.identifier) - cannot unpause a type without an association"
+            }
+            FlowEVMBridgeConfig.updatePauseStatus(type, pause: false)
+        }
+
+        /// Sets the target EVM contract address on the handler for a given Type, associating the Cadence type with the
+        /// provided EVM address. If a TokenHandler does not exist for the given Type, the operation reverts.
+        ///
+        /// @param targetType: Cadence type to associate with the target EVM address
+        /// @param targetEVMAddress: target EVM address to associate with the Cadence type
+        ///
+        /// @emits HandlerConfigured with the target Type, target EVM address, and whether the handler is enabled
+        ///
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun setHandlerTargetEVMAddress(targetType: Type, targetEVMAddress: EVM.EVMAddress) {
+            pre {
+                FlowEVMBridgeConfig.getEVMAddressAssociated(with: targetType) == nil:
+                    "Type already associated with an EVM Address"
+                FlowEVMBridgeConfig.getTypeAssociated(with: targetEVMAddress) == nil:
+                    "EVM Address already associated with another Type"
+            }
+            post {
+                FlowEVMBridgeConfig.getEVMAddressAssociated(with: targetType)!.equals(targetEVMAddress):
+                "Problem associating target Type and target EVM Address"
+            }
+            FlowEVMBridgeConfig.associateType(targetType, with: targetEVMAddress)
+
+            let handler = FlowEVMBridgeConfig.borrowTokenHandlerAdmin(targetType)
+                ?? panic("No handler found for target Type")
+            handler.setTargetEVMAddress(targetEVMAddress)
+
+            emit HandlerConfigured(
+                targetType: targetType.identifier,
+                targetEVMAddress: targetEVMAddress.toString(),
+                isEnabled: handler.isEnabled()
+            )
+        }
+
+        /// Enables the TokenHandler for the given Type. If a TokenHandler does not exist for the given Type, the
+        /// operation reverts.
+        ///
+        /// @param targetType: Cadence type indexing the relevant TokenHandler
+        ///
+        /// @emits HandlerConfigured with the target Type, target EVM address, and whether the handler is enabled
+        ///
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun enableHandler(targetType: Type) {
+            let handler = FlowEVMBridgeConfig.borrowTokenHandlerAdmin(targetType)
+                ?? panic("No handler found for target Type ".concat(targetType.identifier))
+            handler.enableBridging()
+
+            let targetEVMAddressHex = handler.getTargetEVMAddress()?.toString()
+                ?? panic("Handler cannot be enabled without a target EVM Address")
+
+            emit HandlerConfigured(
+                targetType: handler.getTargetType()!.identifier,
+                targetEVMAddress: targetEVMAddressHex,
+                isEnabled: handler.isEnabled()
+            )
+        }
+
+        /// Disables the TokenHandler for the given Type. If a TokenHandler does not exist for the given Type, the
+        /// operation reverts.
+        ///
+        /// @param targetType: Cadence type indexing the relevant TokenHandler
+        ///
+        /// @emits HandlerConfigured with the target Type, target EVM address, and whether the handler is enabled
+        ///
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun disableHandler(targetType: Type) {
+            let handler = FlowEVMBridgeConfig.borrowTokenHandlerAdmin(targetType)
+                ?? panic("No handler found for target Type".concat(targetType.identifier))
+            handler.disableBridging()
+
+            emit HandlerConfigured(
+                targetType: handler.getTargetType()!.identifier,
+                targetEVMAddress: handler.getTargetEVMAddress()?.toString(),
+                isEnabled: handler.isEnabled()
+            )
+        }
+    }
+
+    init() {
+        self.onboardFee = 0.0
+        self.baseFee = 0.0
+        self.defaultDecimals = 18
+        self.gasLimit = 15_000_000
+        self.paused = true
+
+        self.registeredTypes = {}
+        self.evmAddressHexToType = {}
+
+        self.typeToTokenHandlers <- {}
+
+        self.adminStoragePath = /storage/flowEVMBridgeConfigAdmin
+        self.adminPublicPath = /public/flowEVMBridgeConfigAdmin
+        self.coaStoragePath = /storage/evm
+        self.providerCapabilityStoragePath = /storage/bridgeFlowVaultProvider
+
+        // Create & save Admin, issuing a public unentitled Admin Capability
+        self.account.storage.save(<-create Admin(), to: self.adminStoragePath)
+        let adminCap = self.account.capabilities.storage.issue<&Admin>(self.adminStoragePath)
+        self.account.capabilities.publish(adminCap, at: self.adminPublicPath)
+
+        // Initialize the blocklists
+        self.account.storage.save(<-create EVMBlocklist(), to: /storage/evmBlocklist)
+        self.account.storage.save(<-create CadenceBlocklist(), to: /storage/cadenceBlocklist)
+    }
+}

--- a/contracts/external/FlowEVMBridgeCustomAssociations.cdc
+++ b/contracts/external/FlowEVMBridgeCustomAssociations.cdc
@@ -1,0 +1,212 @@
+import "NonFungibleToken"
+import "CrossVMMetadataViews"
+import "EVM"
+
+import "FlowEVMBridgeCustomAssociationTypes"
+
+/// The FlowEVMBridgeCustomAssociations is tasked with preserving custom associations between Cadence assets and their
+/// EVM implementations. These associations should be validated before `saveCustomAssociation` is called by
+/// leveraging the interfaces outlined in FLIP-318 (https://github.com/onflow/flips/issues/318) to ensure that the
+/// declared association is valid and that neither implementation is bridge-defined.
+///
+access(all) contract FlowEVMBridgeCustomAssociations {
+
+    /// Stored associations indexed by Cadence Type
+    access(self) let associationsConfig: @{Type: {FlowEVMBridgeCustomAssociationTypes.CustomConfig}}
+    /// Reverse lookup indexed on serialized EVM contract address
+    access(self) let associationsByEVMAddress: {String: Type}
+
+    /// Event emitted whenever a custom association is established
+    access(all) event CustomAssociationEstablished(
+        type: String,
+        evmContractAddress: String,
+        nativeVMRawValue: UInt8,
+        updatedFromBridged: Bool,
+        fulfillmentMinterType: String?,
+        fulfillmentMinterOrigin: Address?,
+        fulfillmentMinterCapID: UInt64?,
+        fulfillmentMinterUUID: UInt64?,
+        configUUID: UInt64
+    )
+
+    /// Retrieves the EVM address associated with the given Cadence Type if it has been registered as a cross-VM asset
+    ///
+    /// @param with: The Cadence Type to query against
+    ///
+    /// @return The EVM address configured as associated with the provided Cadence Type
+    ///
+    access(all)
+    view fun getEVMAddressAssociated(with type: Type): EVM.EVMAddress? {
+        return self.associationsConfig[type]?.getEVMContractAddress() ?? nil
+    }
+
+    /// Retrieves the Cadence Type associated with the given EVM address if it has been registered as a cross-VM asset
+    ///
+    /// @param with: The EVM contract address to query against
+    ///
+    /// @return The Cadence Type configured as associated with the provided EVM address
+    ///
+    access(all)
+    view fun getTypeAssociated(with evmAddress: EVM.EVMAddress): Type? {
+        return self.associationsByEVMAddress[evmAddress.toString()]
+    }
+
+    /// Returns an EVMPointer containing the data at the time of registration
+    ///
+    /// @param forType: The Cadence Type to query against
+    ///
+    /// @return a copy of the EVMPointer view as registered with the bridge
+    ///
+    access(all)
+    fun getEVMPointerAsRegistered(forType: Type): CrossVMMetadataViews.EVMPointer? {
+        if let config = &self.associationsConfig[forType] as &{FlowEVMBridgeCustomAssociationTypes.CustomConfig}? {
+            return CrossVMMetadataViews.EVMPointer(
+                cadenceType: config.getCadenceType(),
+                cadenceContractAddress: config.getCadenceType().address!,
+                evmContractAddress: config.getEVMContractAddress(),
+                nativeVM: config.getNativeVM()
+            )
+        }
+        return nil
+    }
+
+    /// Returns whether the related CustomConfig is currently paused or not. `nil` is returned if a CustomConfig is not
+    /// found for the given Type
+    ///
+    /// @param forType: The Cadence Type for which to retrieve a registered CustomConfig
+    ///
+    /// @return true if the CustomConfig is paused, false if registered and unpaused, nil if unregistered as a custom
+    ///     association
+    ///
+    access(all)
+    view fun isCustomConfigPaused(forType: Type): Bool? {
+        return self.borrowNFTCustomConfig(forType: forType)?.isPaused() ?? nil
+    }
+
+    /// Returns metadata about a registered CustomConfig
+    ///
+    /// @param forType: The Cadence Type of the registered cross-VM asset
+    ///
+    /// @return The CustomConfigInfo struct if the type is registered, nil otherwise
+    ///
+    access(all)
+    fun getCustomConfigInfo(forType: Type): FlowEVMBridgeCustomAssociationTypes.CustomConfigInfo? {
+        if let config = self.borrowNFTCustomConfig(forType: forType) {
+            let fulfillmentMinterType = config.checkFulfillmentMinter() == true ? config.borrowFulfillmentMinter().getType() : nil
+            return FlowEVMBridgeCustomAssociationTypes.CustomConfigInfo(
+                updatedFromBridged: config.isUpdatedFromBridged(),
+                isPaused: config.isPaused(),
+                fulfillmentMinterType: fulfillmentMinterType,
+                evmPointer: self.getEVMPointerAsRegistered(forType: forType)!
+            )
+        }
+        return nil
+    }
+
+    /// Allows the bridge contracts to preserve a custom association. Will revert if a custom association already exists
+    ///
+    /// @param type: The Cadence Type of the associated asset.
+    /// @param evmContractAddress: The EVM address defining the EVM implementation of the associated asset.
+    /// @param nativeVM: The VM in which the asset is distributed by the project. The bridge will mint/escrow in the non-native
+    ///     VM environment.
+    /// @param updatedFromBridged: Whether the asset was originally onboarded to the bridge via permissionless
+    ///     onboarding. In other words, whether there was first a bridge-defined implementation of the underlying asset.
+    /// @param fulfillmentMinter: An authorized Capability allowing the bridge to fulfill bridge requests moving the
+    ///     underlying asset from EVM. Required if the asset is EVM-native.
+    ///
+    access(account)
+    fun saveCustomAssociation(
+        type: Type,
+        evmContractAddress: EVM.EVMAddress,
+        nativeVM: CrossVMMetadataViews.VM,
+        updatedFromBridged: Bool,
+        fulfillmentMinter: Capability<auth(FlowEVMBridgeCustomAssociationTypes.FulfillFromEVM) &{FlowEVMBridgeCustomAssociationTypes.NFTFulfillmentMinter}>?
+    ) {
+        pre {
+            self.associationsConfig[type] == nil:
+            "Type \(type.identifier) already has a custom association with \(self.borrowNFTCustomConfig(forType: type)!.getEVMContractAddress().toString())"
+            type.isSubtype(of: Type<@{NonFungibleToken.NFT}>()):
+            "Only NFT cross-VM associations are currently supported but \(type.identifier) is not an NFT implementation"
+            self.associationsByEVMAddress[evmContractAddress.toString()] == nil:
+            "EVM Address \(evmContractAddress.toString()) already has a custom association with \(self.associationsByEVMAddress[evmContractAddress.toString()]!.identifier)"
+            fulfillmentMinter?.check() ?? true:
+            "The NFTFulfillmentMinter Capability issued from \(fulfillmentMinter!.address.toString()) is invalid. Ensure the Capability is properly issued and active."
+        }
+        let config <- FlowEVMBridgeCustomAssociationTypes.createNFTCustomConfig(
+                type: type,
+                evmContractAddress: evmContractAddress,
+                nativeVM: nativeVM,
+                updatedFromBridged: updatedFromBridged,
+                fulfillmentMinter: fulfillmentMinter
+            )
+        emit CustomAssociationEstablished(
+            type: type.identifier,
+            evmContractAddress: evmContractAddress.toString(),
+            nativeVMRawValue: nativeVM.rawValue,
+            updatedFromBridged: updatedFromBridged,
+            fulfillmentMinterType: fulfillmentMinter != nil ? fulfillmentMinter!.borrow()!.getType().identifier : nil,
+            fulfillmentMinterOrigin: fulfillmentMinter?.address ?? nil,
+            fulfillmentMinterCapID: fulfillmentMinter?.id ?? nil,
+            fulfillmentMinterUUID: fulfillmentMinter != nil ? fulfillmentMinter!.borrow()!.uuid : nil,
+            configUUID: config.uuid
+        )
+        self.associationsByEVMAddress[config.evmContractAddress.toString()] = type
+        self.associationsConfig[type] <-! config
+    }
+
+    /// Allows bridge contracts to fulfill NFT bridging requests for EVM-native NFTs, using the provided
+    /// NFTFulfillmentMinter Capability provided by the project on cross-VM registration to mint a new NFT.
+    /// **NOTE:** Given the bridge's mint/escrow pattern for the non-native VM, any calls should first check that the 
+    /// requested NFT is not locked in escrow before minting.
+    ///
+    /// @param forType: The Cadence Type of the NFT being fulfilled
+    /// @param id: The ERC721 ID of the requested NFT
+    ///
+    /// @param
+    access(account)
+    fun fulfillNFTFromEVM(forType: Type, id: UInt256): @{NonFungibleToken.NFT} {
+        post {
+            result.getType() == forType:
+            "Requested \(forType.identifier) but got \(result.getType().identifier) on fulfillment from EVM"
+        }
+        let config = self.borrowNFTCustomConfig(forType: forType)
+            ?? panic("No CustomConfig found for type \(forType.identifier) - cannot fulfill NFT \(id) from EVM")
+        let minter = config.borrowFulfillmentMinter()
+        return <- minter.fulfillFromEVM(id: id)
+    }
+
+    /// Sets the associated CustomConfig as paused, preventing bridging operations on the associated implementations.
+    /// Expect a no-op in the event the CustomConfig is already paused
+    ///
+    access(account) fun pauseCustomConfig(forType: Type) {
+        let config = self.borrowNFTCustomConfig(forType: forType)
+            ?? panic("No CustomConfig found for type \(forType.identifier) - cannot pause config that does not exist")
+        if !config.isPaused() {
+            config.setPauseStatus(true)
+        }
+    }
+
+    /// Sets the associated CustomConfig as unpaused, preventing bridging operations on the associated implementations.
+    /// Expect a no-op in the event the CustomConfig is already paused
+    ///
+    access(account) fun unpauseCustomConfig(forType: Type) {
+        let config = self.borrowNFTCustomConfig(forType: forType)
+            ?? panic("No CustomConfig found for type \(forType.identifier) - cannot unpause config that does not exist")
+        if config.isPaused() {
+            config.setPauseStatus(false)
+        }
+    }
+
+    /// Returns a reference to the NFTCustomConfig if it exists, nil otherwise
+    ///
+    access(self) view fun borrowNFTCustomConfig(forType: Type): &FlowEVMBridgeCustomAssociationTypes.NFTCustomConfig? {
+        let config = &self.associationsConfig[forType] as &{FlowEVMBridgeCustomAssociationTypes.CustomConfig}?
+        return config as? &FlowEVMBridgeCustomAssociationTypes.NFTCustomConfig
+    }
+
+
+    init() {
+        self.associationsConfig <- {}
+        self.associationsByEVMAddress = {}
+    }
+}

--- a/contracts/external/FlowEVMBridgeHandlerInterfaces.cdc
+++ b/contracts/external/FlowEVMBridgeHandlerInterfaces.cdc
@@ -1,0 +1,203 @@
+import "FungibleToken"
+import "NonFungibleToken"
+
+import "EVM"
+
+/// FlowEVMBridgeHandlerInterfaces
+///
+/// This contract defines the interfaces for the FlowEVM Bridge Handlers. These Handlers are intended to encapsulate
+/// the logic for bridging edge case assets between Cadence and EVM and require configuration by the bridge account to
+/// enable. Contracts implementing these resources should be deployed to the bridge account so that privileged methods,
+/// particularly those related to fulfilling bridge requests remain in the closed loop of bridge contract logic and
+/// defined assets in the custody of the bridge account.
+///
+access(all) contract FlowEVMBridgeHandlerInterfaces {
+
+    /******************
+        Entitlements
+    *******************/
+
+    /// Entitlement related to administrative setters
+    access(all) entitlement Admin
+    /// Entitlement related to minting handled assets
+    access(all) entitlement Mint
+
+    /*************
+        Events
+    **************/
+    
+    /// Event emitted when a handler is enabled between a Cadence type and an EVM address
+    access(all) event HandlerEnabled(
+        handlerType: String,
+        handlerUUID: UInt64,
+        targetType: String,
+        targetEVMAddress: String
+    )
+    /// Event emitted when a handler is disabled, pausing bridging between VMs
+    access(all) event HandlerDisabled(
+        handlerType: String,
+        handlerUUID: UInt64,
+        targetType: String?,
+        targetEVMAddress: String?
+    )
+    /// Emitted when a minter resource is set in a handler
+    access(all) event MinterSet(handlerType: String,
+        handlerUUID: UInt64,
+        targetType: String?,
+        targetEVMAddress: String?,
+        minterType: String,
+        minterUUID: UInt64
+    )
+
+    /****************
+        Constructs
+    *****************/
+    
+    /// Non-privileged interface for querying handler information
+    ///
+    access(all) resource interface HandlerInfo {
+        /// Returns whether the Handler is enabled
+        access(all) view fun isEnabled(): Bool
+        /// Returns the Cadence type handled by the Handler, nil if not set
+        access(all) view fun getTargetType(): Type?
+        /// Returns the EVM address handled by the Handler, nil if not set
+        access(all) view fun getTargetEVMAddress(): EVM.EVMAddress?
+        /// Returns the Type of the expected minter if the handler utilizes one
+        access(all) view fun getExpectedMinterType(): Type?
+    }
+
+    /// Administrative interface for Handler configuration
+    ///
+    access(all) resource interface HandlerAdmin : HandlerInfo {
+        /// Sets the target Cadence Type handled by this resource. Once the targe type is set - whether by this method
+        /// or on initialization - this setter will fail.
+        access(Admin) fun setTargetType(_ type: Type) {
+            pre {
+                self.getTargetType() == nil: "Target Type has already been set"
+            }
+            post {
+                self.getTargetType()! == type: "Problem setting target type"
+            }
+        }
+        /// Sets the target EVM address handled by this resource
+        access(Admin) fun setTargetEVMAddress(_ address: EVM.EVMAddress) {
+            pre {
+                self.getTargetEVMAddress() == nil: "Target EVM address has already been set"
+            }
+            post {
+                self.getTargetEVMAddress()!.equals(address!): "Problem setting target EVM address"
+            }
+        }
+        access(Admin) fun setMinter(_ minter: @{FlowEVMBridgeHandlerInterfaces.TokenMinter}) {
+            pre {
+                self.getExpectedMinterType() == minter.getType(): "Minter is not of the expected type"
+                minter.getMintedType() == self.getTargetType(): "Minter does not mint the target type"
+                emit MinterSet(
+                    handlerType: self.getType().identifier,
+                    handlerUUID: self.uuid,
+                    targetType: self.getTargetType()?.identifier,
+                    targetEVMAddress: self.getTargetEVMAddress()?.toString(),
+                    minterType: minter.getType().identifier,
+                    minterUUID: minter.uuid
+                )
+            }
+        }
+        /// Enables the Handler to fulfill bridge requests for the configured targets. If implementers utilize a minter,
+        /// they should additionally ensure the minter is set before enabling.
+        access(Admin) fun enableBridging() {
+            pre {
+                self.getTargetType() != nil && self.getTargetEVMAddress() != nil:
+                "Cannot enable before setting bridge target Type and EVM Address"
+                !self.isEnabled(): "Handler has already been enabled"
+            }
+            post {
+                self.isEnabled(): "Problem enabling Handler"
+                emit HandlerEnabled(
+                    handlerType: self.getType().identifier,
+                    handlerUUID: self.uuid,
+                    targetType: self.getTargetType()!.identifier,
+                    targetEVMAddress: self.getTargetEVMAddress()!.toString()
+                )
+            }
+        }
+
+        /// Disables the Handler from fulfilling bridge requests.
+        access(Admin) fun disableBridging() {
+            pre {
+                self.isEnabled():
+                "Cannot disable: \(self.getType().identifier) is already disabled"
+            }
+            post {
+                !self.isEnabled():
+                "Problem disabling ".concat(self.getType().identifier)
+                emit HandlerDisabled(
+                    handlerType: self.getType().identifier,
+                    handlerUUID: self.uuid,
+                    targetType: self.getTargetType()?.identifier,
+                    targetEVMAddress: self.getTargetEVMAddress()?.toString()
+                )
+            }
+        }
+    }
+
+    /// Minter interface for configurations requiring the minting of Cadence fungible tokens
+    ///
+    access(all) resource interface TokenMinter {
+        /// Returns the Cadence type minted by this resource
+        access(all) view fun getMintedType(): Type
+        /// Mints the specified amount of tokens
+        access(Mint) fun mint(amount: UFix64): @{FungibleToken.Vault} {
+            pre {
+                amount > 0.0: "Attempting to mint 0.0 - Amount minted must be greater than 0"
+            }
+            post {
+                result.getType() == self.getMintedType():
+                "TokenMinter ".concat(self.getType().identifier).concat(" with uuid ").concat(self.uuid.toString())
+                    .concat(" expected to mint ").concat(self.getMintedType().identifier)
+                    .concat(" but returned ").concat(result.getType().identifier)
+                result.balance == amount:
+                "Minted amount ".concat(result.balance.toString())
+                    .concat(" does not match requested amount ").concat(amount.toString())
+            }
+        }
+    }
+
+    /// Handler interface for bridging FungibleToken assets. Implementations should be stored within the bridge account
+    /// and called be the bridge contract for bridging operations on the Handler's target Type and EVM contract.
+    ///
+    access(all) resource interface TokenHandler : HandlerAdmin {
+        /// Fulfills a request to bridge tokens from the Cadence side to the EVM side
+        access(account) fun fulfillTokensToEVM(
+            tokens: @{FungibleToken.Vault},
+            to: EVM.EVMAddress
+        ) {
+            pre {
+                self.isEnabled():
+                "TokenHandler \(self.getType().identifier) with uuid \(self.uuid.toString()) is not yet enabled"
+                tokens.getType() == self.getTargetType():
+                "TokenHandler \(self.getType().identifier) with uuid \(self.uuid.toString()) expects \(self.getTargetType()?.identifier ?? "nil") but received \(tokens.getType().identifier)"
+                tokens.balance > 0.0:
+                "Attempting to bridge 0.0 tokens - zero amounts are unsupported"
+            }
+        }
+        /// Fulfills a request to bridge tokens from the EVM side to the Cadence side
+        access(account) fun fulfillTokensFromEVM(
+            owner: EVM.EVMAddress,
+            type: Type,
+            amount: UInt256,
+            protectedTransferCall: fun (): EVM.ResultDecoded
+        ): @{FungibleToken.Vault} {
+            pre {
+                self.isEnabled():
+                "TokenHandler \(self.getType().identifier) with uuid \(self.uuid.toString()) is not yet enabled"
+                amount > 0: "Attempting to bridge 0 tokens from EVM - zero amounts are unsupported"
+            }
+            post {
+                result.getType() == self.getTargetType():
+                "TokenHandler ".concat(self.getType().identifier).concat(" with uuid ").concat(self.uuid.toString())
+                    .concat(" expected to return ").concat(self.getTargetType()?.identifier ?? "nil")
+                    .concat(" but returned ").concat(result.getType().identifier)
+            }
+        }
+    }
+}

--- a/contracts/external/FlowEVMBridgeHandlers.cdc
+++ b/contracts/external/FlowEVMBridgeHandlers.cdc
@@ -1,0 +1,458 @@
+import "Burner"
+import "FungibleToken"
+import "NonFungibleToken"
+import "FlowToken"
+
+import "EVM"
+
+import "FlowEVMBridgeHandlerInterfaces"
+import "FlowEVMBridgeConfig"
+import "FlowEVMBridgeUtils"
+
+/// FlowEVMBridgeHandlers
+///
+/// This contract is responsible for defining and configuring bridge handlers for special cased assets.
+///
+access(all) contract FlowEVMBridgeHandlers {
+
+    /**********************
+        Contract Fields
+    ***********************/
+
+    /// The storage path for the HandlerConfigurator resource
+    access(all) let ConfiguratorStoragePath: StoragePath
+
+    /****************
+        Constructs
+    *****************/
+
+    /// Handler for bridging Cadence native fungible tokens to EVM. In the event a Cadence project migrates native
+    /// support to EVM, this Hander can be configured to facilitate bridging the Cadence tokens to EVM. This Handler
+    /// then effectively allows the bridge to treat such tokens as bridge-defined on the Cadence side and EVM-native on
+    /// the EVM side minting/burning in Cadence and escrowing in EVM.
+    /// In order for this to occur, neither the Cadence token nor the EVM contract can be onboarded to the bridge - in
+    /// essence, neither side of the asset can be onboarded to the bridge.
+    /// The Handler must be configured in the bridge via the HandlerConfigurator. Once added, the bridge will filter
+    /// requests to bridge the token Vault to EVM through this Handler which cannot be enabled until a target EVM
+    /// address is set. Once the corresponding EVM contract address is known, it can be set and the Handler. It's also
+    /// suggested that the Handler only be enabled once sufficient liquidity has been arranged in bridge escrow on the
+    /// EVM side.
+    ///
+    access(all) resource CadenceNativeTokenHandler : FlowEVMBridgeHandlerInterfaces.TokenHandler {
+        /// Flag determining if request handling is enabled
+        access(self) var enabled: Bool
+        /// The Cadence Type this handler fulfills requests for
+        access(self) var targetType: Type
+        /// The EVM contract address this handler fulfills requests for. This field is optional in the event the EVM
+        /// contract address is not yet known but the Cadence type must still be filtered via Handler to prevent the
+        /// type from being onboarded otherwise.
+        access(self) var targetEVMAddress: EVM.EVMAddress?
+        /// The expected minter type for minting tokens on fulfillment
+        access(self) let expectedMinterType: Type
+        /// The Minter enabling minting of Cadence tokens on fulfillment from EVM
+        access(self) var minter: @{FlowEVMBridgeHandlerInterfaces.TokenMinter}?
+
+        init(targetType: Type, targetEVMAddress: EVM.EVMAddress?, expectedMinterType: Type) {
+            pre {
+                expectedMinterType.isSubtype(of: Type<@{FlowEVMBridgeHandlerInterfaces.TokenMinter}>()):
+                    "Invalid minter type"
+            }
+            self.enabled = false
+            self.targetType = targetType
+            self.targetEVMAddress = targetEVMAddress
+            self.expectedMinterType = expectedMinterType
+            self.minter <- nil
+        }
+
+        /* --- HandlerInfo --- */
+
+        /// Returns the enabled status of the handler
+        access(all) view fun isEnabled(): Bool {
+            return self.enabled
+        }
+
+        /// Returns the type of the asset the handler is configured to handle
+        access(all) view fun getTargetType(): Type? {
+            return self.targetType
+        }
+
+        /// Returns the EVM contract address the handler is configured to handle
+        access(all) view fun getTargetEVMAddress(): EVM.EVMAddress? {
+            return self.targetEVMAddress
+        }
+
+        /// Returns the expected minter type for the handler
+        access(all) view fun getExpectedMinterType(): Type? {
+            return self.expectedMinterType
+        }
+
+        /* --- TokenHandler --- */
+
+        /// Fulfill a request to bridge tokens from Cadence to EVM, burning the provided Vault and transferring from
+        /// EVM escrow to the named recipient. Assumes any fees are handled by the caller within the bridge contracts
+        ///
+        /// @param tokens: The Vault containing the tokens to bridge
+        /// @param to: The EVM address to transfer the tokens to
+        ///
+        access(account)
+        fun fulfillTokensToEVM(
+            tokens: @{FungibleToken.Vault},
+            to: EVM.EVMAddress
+        ) {
+            let evmAddress = self.getTargetEVMAddress()!
+
+            // Get values from vault and burn
+            let amount = tokens.balance
+            let uintAmount = FlowEVMBridgeUtils.convertCadenceAmountToERC20Amount(amount, erc20Address: evmAddress)
+
+            assert(uintAmount > 0, message: "Amount to bridge must be greater than 0")
+
+            Burner.burn(<-tokens)
+
+            FlowEVMBridgeUtils.mustTransferERC20(to: to, amount: uintAmount, erc20Address: evmAddress)
+        }
+
+        /// Fulfill a request to bridge tokens from EVM to Cadence, minting the provided amount of tokens in Cadence
+        /// and transferring from the named owner to bridge escrow in EVM.
+        ///
+        /// @param owner: The EVM address of the owner of the tokens. Should also be the caller executing the protected
+        ///              transfer call.
+        /// @param type: The type of the asset being bridged
+        /// @param amount: The amount of tokens to bridge
+        ///
+        /// @return The minted Vault containing the the requested amount of Cadence tokens
+        ///
+        access(account)
+        fun fulfillTokensFromEVM(
+            owner: EVM.EVMAddress,
+            type: Type,
+            amount: UInt256,
+            protectedTransferCall: fun (): EVM.ResultDecoded
+        ): @{FungibleToken.Vault} {
+            let evmAddress = self.getTargetEVMAddress()!
+
+            // Convert the amount to a UFix64
+            let ufixAmount = FlowEVMBridgeUtils.convertERC20AmountToCadenceAmount(
+                    amount,
+                    erc20Address: evmAddress
+                )
+            assert(ufixAmount > 0.0, message: "Amount to bridge must be greater than 0")
+
+            FlowEVMBridgeUtils.mustEscrowERC20(
+                owner: owner,
+                amount: amount,
+                erc20Address: evmAddress,
+                protectedTransferCall: protectedTransferCall
+            )
+
+            // After state confirmation, mint the tokens and return
+            let minter = self.borrowMinter()
+                ?? panic("Cannot bridge - Minter not set in \(self.getType().identifier)")
+            let minted <- minter.mint(amount: ufixAmount)
+            return <-minted
+        }
+
+        /* --- Admin --- */
+
+        /// Sets the target type for the handler
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun setTargetType(_ type: Type) {
+            self.targetType = type
+        }
+
+        /// Sets the target EVM address for the handler
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun setTargetEVMAddress(_ address: EVM.EVMAddress) {
+            self.targetEVMAddress = address
+        }
+
+        /// Sets the target type for the handler
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun setMinter(_ minter: @{FlowEVMBridgeHandlerInterfaces.TokenMinter}) {
+            pre {
+                self.minter == nil: "Minter has already been set in \(self.getType().identifier)"
+            }
+            self.minter <-! minter
+        }
+
+        /// Enables the handler for request handling.
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun enableBridging() {
+            pre {
+                self.minter != nil: "Cannot enable \(self.getType().identifier) without a minter"
+            }
+            self.enabled = true
+        }
+
+        /// Disables the handler for request handling.
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun disableBridging() {
+            self.enabled = false
+        }
+
+        /* --- Internal --- */
+
+        /// Returns an entitled reference to the encapsulated minter resource
+        access(self)
+        view fun borrowMinter(): auth(FlowEVMBridgeHandlerInterfaces.Mint) &{FlowEVMBridgeHandlerInterfaces.TokenMinter}? {
+            return &self.minter
+        }
+    }
+
+    /// Facilitates moving Flow between Cadence and EVM as WFLOW. Since WFLOW is an artifact of the EVM ecosystem, 
+    /// wrapping the native token as an ERC20, it does not have a place in Cadence's fungible token ecosystem.
+    /// Given the native interface on EVM.CadenceOwnedAccount and EVM.EVMAddress to move FLOW between Cadence and EVM,
+    /// this handler treats requests to bridge FLOW as WFLOW as a special case.
+    ///
+    access(all) resource WFLOWTokenHandler : FlowEVMBridgeHandlerInterfaces.TokenHandler {
+        /// Flag determining if request handling is enabled
+        access(self) var enabled: Bool
+        /// The Cadence Type this handler fulfills requests for
+        access(self) var targetType: Type
+        /// The EVM contract address this handler fulfills requests for
+        access(self) var targetEVMAddress: EVM.EVMAddress
+
+        init(wflowEVMAddress: EVM.EVMAddress) {
+            self.enabled = false
+            self.targetType = Type<@FlowToken.Vault>()
+            self.targetEVMAddress = wflowEVMAddress
+        }
+
+        /// Returns whether the Handler is enabled
+        access(all) view fun isEnabled(): Bool {
+            return self.enabled
+        }
+        /// Returns the Cadence type handled by the Handler, nil if not set
+        access(all) view fun getTargetType(): Type? {
+            return self.targetType
+        }
+        /// Returns the EVM address handled by the Handler, nil if not set
+        access(all) view fun getTargetEVMAddress(): EVM.EVMAddress? {
+            return self.targetEVMAddress
+        }
+        /// Returns nil as this handler simply unwraps WFLOW to FLOW
+        access(all) view fun getExpectedMinterType(): Type? {
+            return nil
+        }
+
+        /* --- TokenHandler --- */
+
+        /// Fulfill a request to bridge tokens from Cadence to EVM, burning the provided Vault and transferring from
+        /// EVM escrow to the named recipient. Assumes any fees are handled by the caller within the bridge contracts
+        ///
+        /// @param tokens: The Vault containing the tokens to bridge
+        /// @param to: The EVM address to transfer the tokens to
+        ///
+        access(account)
+        fun fulfillTokensToEVM(
+            tokens: @{FungibleToken.Vault},
+            to: EVM.EVMAddress
+        ) {
+            let flowVault <- tokens as! @FlowToken.Vault
+            let wflowAddress = self.getTargetEVMAddress()!
+
+            // Get balance from vault
+            let balance = flowVault.balance
+            let uintAmount = FlowEVMBridgeUtils.convertCadenceAmountToERC20Amount(balance, erc20Address: wflowAddress)
+
+            // Deposit to bridge COA
+            let coa = FlowEVMBridgeUtils.borrowCOA()
+            coa.deposit(from: <-flowVault)
+
+            let preBalance = FlowEVMBridgeUtils.balanceOf(owner: coa.address(), evmContractAddress: wflowAddress)
+
+            // Wrap the deposited FLOW as WFLOW, giving the bridge COA the necessary WFLOW to transfer
+            let wrapResult = FlowEVMBridgeUtils.callWithSigAndArgs(
+                signature: "deposit()",
+                targetEVMAddress: wflowAddress,
+                args: [],
+                gasLimit: FlowEVMBridgeConfig.gasLimit,
+                value: balance,
+                resultTypes: nil
+            )
+            assert(wrapResult.status == EVM.Status.successful, message: "Failed to wrap FLOW as WFLOW")
+            
+            let postBalance = FlowEVMBridgeUtils.balanceOf(owner: coa.address(), evmContractAddress: wflowAddress)
+
+            // Cover underflow
+            assert(
+                postBalance > preBalance,
+                message: "Escrowed WFLOW balance did not increment after wrapping FLOW - pre: \(preBalance.toString()) | post: \(postBalance.toString())"
+            )
+            // Confirm bridge COA's WFLOW balance has incremented by the expected amount
+            assert(
+                postBalance - preBalance == uintAmount,
+                message: "Escrowed WFLOW balance after wrapping does not match requested amount - expected: \(preBalance + uintAmount).toString()) | actual: \(postBalance - preBalance).toString())"
+            )
+
+            // Transfer WFLOW to recipient
+            FlowEVMBridgeUtils.mustTransferERC20(to: to, amount: uintAmount, erc20Address: wflowAddress)
+        }
+
+        /// Fulfill a request to bridge tokens from EVM to Cadence, minting the provided amount of tokens in Cadence
+        /// and transferring from the named owner to bridge escrow in EVM.
+        ///
+        /// @param owner: The EVM address of the owner of the tokens. Should also be the caller executing the protected
+        ///              transfer call.
+        /// @param type: The type of the asset being bridged
+        /// @param amount: The amount of tokens to bridge
+        ///
+        /// @return The minted Vault containing the the requested amount of Cadence tokens
+        ///
+        access(account)
+        fun fulfillTokensFromEVM(
+            owner: EVM.EVMAddress,
+            type: Type,
+            amount: UInt256,
+            protectedTransferCall: fun (): EVM.ResultDecoded
+        ): @{FungibleToken.Vault} {
+            let wflowAddress = self.getTargetEVMAddress()!
+
+            // Convert the amount to a UFix64
+            let ufixAmount = FlowEVMBridgeUtils.convertERC20AmountToCadenceAmount(
+                    amount,
+                    erc20Address: wflowAddress
+                )
+            assert(
+                ufixAmount > 0.0,
+                message: "Requested UInt256 amount \(amount.toString()) converted to 0.0  - try bridging a larger amount to avoid UFix64 precision loss during conversion"
+            )
+
+            // Transfers WFLOW to bridge COA as escrow
+            FlowEVMBridgeUtils.mustEscrowERC20(
+                owner: owner,
+                amount: amount,
+                erc20Address: wflowAddress,
+                protectedTransferCall: protectedTransferCall
+            )
+
+            // Get the bridge COA's FLOW balance before unwrapping WFLOW
+            let coa = FlowEVMBridgeUtils.borrowCOA()
+            let preBalance = coa.balance().attoflow
+
+            // Unwrap the transferred WFLOW to FLOW, giving the bridge COA the necessary FLOW to withdraw from EVM
+            let unwrapResult = FlowEVMBridgeUtils.callWithSigAndArgs(
+                signature: "withdraw(uint256)",
+                targetEVMAddress: wflowAddress,
+                args: [amount],
+                gasLimit: FlowEVMBridgeConfig.gasLimit,
+                value: 0.0,
+                resultTypes: nil
+            )
+            assert(unwrapResult.status == EVM.Status.successful, message: "Failed to unwrap WFLOW as FLOW")
+
+            let postBalance = coa.balance().attoflow
+
+            // Cover underflow
+            assert(
+                postBalance > preBalance,
+                message: "Escrowed FLOW Balance did not increment after unwrapping WFLOW - pre: \(preBalance.toString()) | post: \(postBalance.toString())"
+            )
+            // Confirm bridge COA's FLOW balance has incremented by the expected amount
+            assert(
+                UInt256(postBalance - preBalance) == amount,
+                message: "Escrowed WFLOW balance after unwrapping does not match requested amount - expected: \(UInt256(preBalance) + amount).toString()) | actual: \(postBalance - preBalance).toString())"
+            )
+
+            // Withdraw escrowed FLOW from bridge COA.
+            // EVM.Balance takes a UInt (64-bit on all supported platforms). `UInt(amount)` truncates silently if
+            // `amount > UInt.max`. The assert immediately below catches any truncation: if truncation occurred,
+            // `UInt256(withdrawBalance.attoflow) != amount` and the transaction reverts. In practice this cannot
+            // trigger: total FLOW supply is ~1.25B × 10^18 attoflow ≈ 1.25e27, far below UInt.max (~1.8e19 × 1e9
+            // = 1.8e28 for 64-bit). No valid WFLOW bridge request can produce an amount large enough to truncate.
+            let withdrawBalance = EVM.Balance(attoflow: UInt(amount))
+            assert(
+                UInt256(withdrawBalance.attoflow) == amount,
+                message: "Requested balance failed to convert to attoflow - expected: \(amount.toString()) | actual: \(withdrawBalance.attoflow.toString())"
+            )
+            let flowVault <- coa.withdraw(balance: withdrawBalance)
+            assert(
+                flowVault.balance == ufixAmount,
+                message: "Resulting FLOW Vault balance does not match requested amount - expected: \(ufixAmount.toString()) | actual: \(flowVault.balance.toString())"
+            )
+            return <-flowVault
+        }
+
+        /* --- HandlerAdmin --- */
+        // Conforms to HandlerAdmin for enableBridging, but most of the methods are unnecessary given the strict
+        // association between FLOW and WFLOW
+
+        /// Sets the target type for the handler
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun setTargetType(_ type: Type) {
+            panic("WFLOWTokenHandler has targetType set to \(self.targetType.identifier) at initialization")
+        }
+
+        /// Sets the target EVM address for the handler
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun setTargetEVMAddress(_ address: EVM.EVMAddress) {
+            panic("WFLOWTokenHandler has EVMAddress set to \(self.targetEVMAddress.toString()) at initialization")
+        }
+
+        /// Sets the target type for the handler
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun setMinter(_ minter: @{FlowEVMBridgeHandlerInterfaces.TokenMinter}) {
+            panic("WFLOWTokenHandler does not utilize a minter")
+        }
+
+        /// Enables the handler for request handling. The
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun enableBridging() {
+            self.enabled = true
+        }
+
+        /// Disables the handler for request handling.
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun disableBridging() {
+            self.enabled = false
+        }
+    }
+
+    /// This resource enables the configuration of Handlers. These Handlers are stored in FlowEVMBridgeConfig from which
+    /// further setting and getting can be executed.
+    ///
+    access(all) resource HandlerConfigurator {
+        /// Creates a new Handler and adds it to the bridge configuration
+        ///
+        /// @param handlerType: The type of handler to create as defined in this contract
+        /// @param targetType: The type of the asset the handler will handle
+        /// @param targetEVMAddress: The EVM contract address the handler will handle, can be nil if still unknown
+        /// @param expectedMinterType: The Type of the expected minter to be set for the created TokenHandler
+        ///
+        access(FlowEVMBridgeHandlerInterfaces.Admin)
+        fun createTokenHandler(
+            handlerType: Type,
+            targetType: Type,
+            targetEVMAddress: EVM.EVMAddress?,
+            expectedMinterType: Type?
+        ) {
+            switch handlerType {
+                case Type<@CadenceNativeTokenHandler>():
+                    assert(
+                        expectedMinterType != nil,
+                        message: "CadenceNativeTokenHandler requires an expected minter type but received nil"
+                    )
+                    let handler <-create CadenceNativeTokenHandler(
+                        targetType: targetType,
+                        targetEVMAddress: targetEVMAddress,
+                        expectedMinterType: expectedMinterType!
+                    )
+                    FlowEVMBridgeConfig.addTokenHandler(<-handler)
+                case Type<@WFLOWTokenHandler>():
+                    assert(
+                        targetEVMAddress != nil,
+                        message: "WFLOWTokenHandler requires a target EVM address but received nil"
+                    )
+                    let handler <-create WFLOWTokenHandler(wflowEVMAddress: targetEVMAddress!)
+                    FlowEVMBridgeConfig.addTokenHandler(<-handler)
+                default:
+                    panic("Invalid Handler type requested")
+            }
+        }
+    }
+
+    init() {
+        self.ConfiguratorStoragePath = /storage/BridgeHandlerConfigurator
+        self.account.storage.save(<-create HandlerConfigurator(), to: self.ConfiguratorStoragePath)
+    }
+}

--- a/contracts/external/FlowEVMBridgeUtils.cdc
+++ b/contracts/external/FlowEVMBridgeUtils.cdc
@@ -1,0 +1,1693 @@
+import "NonFungibleToken"
+import "FungibleToken"
+import "MetadataViews"
+import "CrossVMMetadataViews"
+import "FungibleTokenMetadataViews"
+import "ViewResolver"
+import "FlowToken"
+import "FlowStorageFees"
+
+import "EVM"
+
+import "SerializeMetadata"
+import "FlowEVMBridgeConfig"
+import "CrossVMNFT"
+import "IBridgePermissions"
+
+/// This contract serves as a source of utility methods leveraged by FlowEVMBridge contracts
+
+/***************************************************************************************
+ Clarification of Flow EVM Bridge Security Model
+
+ The bridge operates under a "trust-but-verify" model for EVM contracts:
+
+ Trust Assumptions
+ - ERC20/ERC721 contracts correctly implement their respective standards.
+ - `balanceOf()`, `ownerOf()`, and similar view functions return accurate state.
+ - `transfer()`, `transferFrom()`, and similar mutating functions perform real state changes.
+ - Emitted events correspond to actual state transitions.
+
+ Security Boundaries
+ The bridge provides the following security guarantees:
+
+ 1. Type Isolation: Each bridged ERC20/ERC721 maps to a unique Cadence type
+    (e.g., `EVMVMBridgedToken_0x{ADDRESS}.Vault`). Cadence's type system ensures
+    complete isolation between different token types.
+
+ 2. Cross-Asset Protection: A vulnerability or malicious behavior in one bridged
+    asset CANNOT affect any other bridged asset. Each type has independent accounting.
+
+ 3. Protocol Asset Protection: Core protocol assets (FlowToken, etc.) are not
+    exposed to risks from user-deployed EVM contracts.
+
+ Flow EVM Bridge design - Security Consideration
+
+ The bridge CANNOT protect against:
+
+ - Malicious ERC20/ERC721 contracts that return fabricated data from view functions
+   or fail to perform real state changes. Such contracts can cause accounting desync
+   for their own token type, but cannot affect other assets.
+
+ - Token developer malfeasance ("rug pulls"). A developer who controls a token
+   contract can harm holders of that specific token through various means, with or
+   without the bridge.
+
+ 
+ The bridge's role is to faithfully execute cross-VM transfers for well-behaved
+ contracts, not to enforce correct behavior of arbitrary EVM code.
+
+ User Responsibility
+
+ Users interacting with bridged assets should:
+ - Verify the legitimacy of ERC20/ERC721 contracts before bridging.
+ - Understand that the bridge cannot guarantee the behavior of arbitrary EVM contracts.
+***************************************************************************************/
+
+access(all)
+contract FlowEVMBridgeUtils {
+
+    /// Address of the bridge factory Solidity contract
+    access(self)
+    var bridgeFactoryEVMAddress: EVM.EVMAddress
+    /// Delimeter used to derive contract names
+    access(self)
+    let delimiter: String
+    /// Mapping containing contract name prefixes
+    access(self)
+    let contractNamePrefixes: {Type: {String: String}}
+
+    /****************
+        Constructs
+    *****************/
+
+    /// Struct used to preserve and pass around multiple values relating to Cadence asset onboarding
+    ///
+    access(all) struct CadenceOnboardingValues {
+        access(all) let contractAddress: Address
+        access(all) let name: String
+        access(all) let symbol: String
+        access(all) let identifier: String
+        access(all) let contractURI: String
+
+        init(
+            contractAddress: Address,
+            name: String,
+            symbol: String,
+            identifier: String,
+            contractURI: String
+        ) {
+            self.contractAddress = contractAddress
+            self.name = name
+            self.symbol = symbol
+            self.identifier = identifier
+            self.contractURI = contractURI
+        }
+    }
+
+    /// Struct used to preserve and pass around multiple values preventing the need to make multiple EVM calls
+    /// during EVM asset onboarding
+    ///
+    access(all) struct EVMOnboardingValues {
+        access(all) let evmContractAddress: EVM.EVMAddress
+        access(all) let name: String
+        access(all) let symbol: String
+        access(all) let decimals: UInt8?
+        access(all) let contractURI: String?
+        access(all) let cadenceContractName: String
+        access(all) let isERC721: Bool
+
+        init(
+            evmContractAddress: EVM.EVMAddress,
+            name: String,
+            symbol: String,
+            decimals: UInt8?,
+            contractURI: String?,
+            cadenceContractName: String,
+            isERC721: Bool
+        ) {
+            self.evmContractAddress = evmContractAddress
+            self.name = name
+            self.symbol = symbol
+            self.decimals = decimals
+            self.contractURI = contractURI
+            self.cadenceContractName = cadenceContractName
+            self.isERC721 = isERC721
+        }
+    }
+
+    /**************************
+        Public Bridge Utils
+     **************************/
+
+    /// Retrieves the bridge factory contract address
+    ///
+    /// @returns The EVMAddress of the bridge factory contract in EVM
+    ///
+    access(all)
+    view fun getBridgeFactoryEVMAddress(): EVM.EVMAddress {
+        return self.bridgeFactoryEVMAddress
+    }
+
+    /// Calculates the fee bridge fee based on the given storage usage + the current base fee.
+    ///
+    /// @param used: The amount of storage used by the asset
+    ///
+    /// @return The calculated fee amount
+    ///
+    access(all)
+    view fun calculateBridgeFee(bytes used: UInt64): UFix64 {
+        let megabytesUsed = FlowStorageFees.convertUInt64StorageBytesToUFix64Megabytes(used)
+        let storageFee = FlowStorageFees.storageCapacityToFlow(megabytesUsed)
+        return storageFee + FlowEVMBridgeConfig.baseFee
+    }
+
+    /// Returns whether the given type is allowed to be bridged as defined by the IBridgePermissions contract interface.
+    /// If the type's defining contract does not implement IBridgePermissions, the method returns true as the bridge
+    /// operates permissionlessly by default. Otherwise, the result of {IBridgePermissions}.allowsBridging() is returned
+    ///
+    /// @param type: The Type of the asset to check
+    ///
+    /// @return true if the type is allowed to be bridged, false otherwise
+    ///
+    access(all)
+    view fun typeAllowsBridging(_ type: Type): Bool {
+        let contractAddress = self.getContractAddress(fromType: type)
+            ?? panic("Could not construct contract address from type identifier: \(type.identifier)")
+        let contractName = self.getContractName(fromType: type)
+            ?? panic("Could not construct contract name from type identifier: \(type.identifier)")
+        if let bridgePermissions = getAccount(contractAddress).contracts.borrow<&{IBridgePermissions}>(name: contractName) {
+            return bridgePermissions.allowsBridging()
+        }
+        return true
+    }
+
+    /// Returns whether the given address has opted out of enabling bridging for its defined assets
+    ///
+    /// @param address: The EVM contract address to check
+    ///
+    /// @return false if the address has opted out of enabling bridging, true otherwise
+    ///
+    access(all)
+    fun evmAddressAllowsBridging(_ address: EVM.EVMAddress): Bool {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "allowsBridging()",
+            targetEVMAddress: address,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<Bool>()]
+        )
+        // Contract doesn't support the method - proceed permissionlessly
+        if callResult.status != EVM.Status.successful {
+            return true
+        }
+        // Contract is IBridgePermissions - return the result
+        return (callResult.results.length == 1 && callResult.results[0] as! Bool) == true ? true : false
+    }
+
+    /// Identifies if an asset is Cadence- or EVM-native, defined by whether a bridge contract defines it or not
+    ///
+    /// @param type: The Type of the asset to check
+    ///
+    /// @return True if the asset is Cadence-native, false if it is EVM-native
+    ///
+    access(all)
+    view fun isCadenceNative(type: Type): Bool {
+        let definingAddress = self.getContractAddress(fromType: type)
+            ?? panic("Could not construct address from type identifier: \(type.identifier)")
+        return definingAddress != self.account.address
+    }
+
+    /// Identifies if an asset is a type that is defined by a bridge-owned Cadence contract. For NFTs, this would
+    /// indicate that the NFT is a bridged representation of a corresponding ERC721. For a Vault, this would
+    /// indicate that the Vault is a bridged representation of a corresponding ERC20.
+    ///
+    /// @param type: The Type of the asset to check
+    ///
+    /// @return True if the asset is bridge-defined, false if another Cadence contract defines the type. Reverts if the
+    ///     type is a primitive type that is not defined by a Cadence contract.
+    ///
+    access(all)
+    view fun isBridgeDefined(type: Type): Bool {
+        let definingAddress = self.getContractAddress(fromType: type)
+            ?? panic("Could not construct address from type identifier: \(type.identifier)")
+        return definingAddress == self.account.address
+    }
+
+    /// Identifies if an asset is Cadence- or EVM-native, defined by whether a bridge-owned contract defines it or not.
+    /// Reverts on EVM call failure.
+    ///
+    /// @param type: The Type of the asset to check
+    ///
+    /// @return True if the asset is EVM-native, false if it is Cadence-native
+    ///
+    access(all)
+    fun isEVMNative(evmContractAddress: EVM.EVMAddress): Bool {
+        return self.isEVMContractBridgeOwned(evmContractAddress: evmContractAddress) == false
+    }
+
+    /// Determines if the given EVM contract address was deployed by the bridge by querying the factory contract
+    /// Reverts on EVM call failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to check
+    ///
+    /// @return True if the contract was deployed by the bridge, false otherwise
+    ///
+    access(all)
+    fun isEVMContractBridgeOwned(evmContractAddress: EVM.EVMAddress): Bool {
+        // Ask the bridge factory if the given contract address was deployed by the bridge
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "isBridgeDeployed(address)",
+            targetEVMAddress: self.bridgeFactoryEVMAddress,
+            args: [evmContractAddress],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<Bool>()]
+        )
+
+        assert(callResult.status == EVM.Status.successful, message: "Call to bridge factory failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+
+        return callResult.results[0] as! Bool
+    }
+
+    /// Identifies if an asset is ERC721. Reverts on EVM call failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to check
+    ///
+    /// @return True if the asset is an ERC721, false otherwise
+    ///
+    access(all)
+    fun isERC721(evmContractAddress: EVM.EVMAddress): Bool {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "isERC721(address)",
+            targetEVMAddress: self.bridgeFactoryEVMAddress,
+            args: [evmContractAddress],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<Bool>()]
+        )
+
+        assert(callResult.status == EVM.Status.successful, message: "Call to bridge factory failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+
+        return callResult.results[0] as! Bool
+    }
+
+    /// Identifies if an asset is ERC20 as far as is possible without true EVM type introspection. Reverts on EVM call
+    /// failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to check
+    ///
+    /// @return true if the asset is an ERC20, false otherwise
+    ///
+    access(all)
+    fun isERC20(evmContractAddress: EVM.EVMAddress): Bool {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "isERC20(address)",
+            targetEVMAddress: self.bridgeFactoryEVMAddress,
+            args: [evmContractAddress],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<Bool>()]
+        )
+
+        assert(callResult.status == EVM.Status.successful, message: "Call to bridge factory failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+
+        return callResult.results[0] as! Bool
+    }
+
+    /// Returns whether the contract address is either an ERC721 or ERC20 exclusively. Reverts on EVM call failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to check
+    ///
+    /// @return True if the contract is either an ERC721 or ERC20, false otherwise
+    ///
+    access(all)
+    fun isValidEVMAsset(evmContractAddress: EVM.EVMAddress): Bool {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "isValidAsset(address)",
+            targetEVMAddress: self.bridgeFactoryEVMAddress,
+            args: [evmContractAddress],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<Bool>()]
+        )
+        assert(callResult.results.length == 1, message: "Invalid response length")
+        return callResult.results[0] as! Bool
+    }
+
+    /// Returns whether the given type is either an NFT or FT exclusively
+    ///
+    /// @param type: The Type of the asset to check
+    ///
+    /// @return True if the type is either an NFT or FT, false otherwise
+    ///
+    access(all)
+    view fun isValidCadenceAsset(type: Type): Bool {
+        let isCadenceNFT = type.isSubtype(of: Type<@{NonFungibleToken.NFT}>())
+        let isCadenceFungibleToken = type.isSubtype(of: Type<@{FungibleToken.Vault}>())
+        return isCadenceNFT != isCadenceFungibleToken
+    }
+
+    /// Retrieves the bridge contract's COA EVMAddress
+    ///
+    /// @returns The EVMAddress of the bridge contract's COA orchestrating actions in FlowEVM
+    ///
+    access(all)
+    view fun getBridgeCOAEVMAddress(): EVM.EVMAddress {
+        return self.borrowCOA().address()
+    }
+
+    /// Retrieves the relevant information for onboarding a Cadence asset to the bridge. This method is used to
+    /// retrieve the name, symbol, contract address, and contract URI for a given Cadence asset type. These values
+    /// are used to then deploy a corresponding EVM contract. If EVMBridgedMetadata is supported by the asset's
+    /// defining contract, the values are retrieved from that view. Otherwise, the values are derived from other
+    /// common metadata views.
+    ///
+    /// @param forAssetType: The Type of the asset to retrieve onboarding values for
+    ///
+    /// @return The CadenceOnboardingValues struct containing the asset's name, symbol, identifier, contract address,
+    ///     and contract URI
+    ///
+    access(all)
+    fun getCadenceOnboardingValues(forAssetType: Type): CadenceOnboardingValues {
+        pre {
+            self.isValidCadenceAsset(type: forAssetType): "This type is not a supported Flow asset type."
+        }
+        // If not an NFT, assumed to be fungible token.
+        let isNFT = forAssetType.isSubtype(of: Type<@{NonFungibleToken.NFT}>())
+
+        // Retrieve the Cadence type's defining contract name, address, & its identifier
+        var name = self.getContractName(fromType: forAssetType)
+            ?? panic("Could not contract name from type: \(forAssetType.identifier)")
+        let identifier = forAssetType.identifier
+        let cadenceAddress = self.getContractAddress(fromType: forAssetType)
+            ?? panic("Could not derive contract address for token type: \(identifier)")
+        // Initialize asset symbol which will be assigned later
+        // based on presence of asset-defined metadata
+        var symbol: String? = nil
+        // Borrow the ViewResolver to attempt to resolve the EVMBridgedMetadata view
+        let viewResolver = getAccount(cadenceAddress).contracts.borrow<&{ViewResolver}>(name: name)!
+        var contractURI = ""
+
+        // Try to resolve the EVMBridgedMetadata
+        let bridgedMetadata = viewResolver.resolveContractView(
+                resourceType: forAssetType,
+                viewType: Type<MetadataViews.EVMBridgedMetadata>()
+            ) as! MetadataViews.EVMBridgedMetadata?
+        // Default to project-defined URI if available
+        if bridgedMetadata != nil {
+            name = bridgedMetadata!.name
+            symbol = bridgedMetadata!.symbol
+            contractURI = bridgedMetadata!.uri.uri()
+        } else {
+            if isNFT {
+                // Otherwise, serialize collection-level NFTCollectionDisplay
+                if let collectionDisplay = viewResolver.resolveContractView(
+                    resourceType: forAssetType,
+                    viewType: Type<MetadataViews.NFTCollectionDisplay>()
+                ) as! MetadataViews.NFTCollectionDisplay? {
+                    name = collectionDisplay.name
+                    let serializedDisplay = SerializeMetadata.serializeFromDisplays(nftDisplay: nil, collectionDisplay: collectionDisplay)!
+                    contractURI = "data:application/json;utf8,{\(serializedDisplay)}"
+                }
+                if symbol == nil {
+                    symbol = SerializeMetadata.deriveSymbol(fromString: name)
+                }
+            } else {
+                let ftDisplay = viewResolver.resolveContractView(
+                    resourceType: forAssetType,
+                    viewType: Type<FungibleTokenMetadataViews.FTDisplay>()
+                ) as! FungibleTokenMetadataViews.FTDisplay?
+                if ftDisplay != nil {
+                    name = ftDisplay!.name
+                    symbol = ftDisplay!.symbol
+                }
+                if contractURI.length == 0 && ftDisplay != nil {
+                    let serializedDisplay = SerializeMetadata.serializeFTDisplay(ftDisplay!)
+                    contractURI = "data:application/json;utf8,{\(serializedDisplay)}"
+                }
+                // Derive a symbol from the name if no metadata view provided one
+                if symbol == nil {
+                    symbol = SerializeMetadata.deriveSymbol(fromString: name)
+                }
+            }
+        }
+
+        return CadenceOnboardingValues(
+            contractAddress: cadenceAddress,
+            name: name,
+            symbol: symbol!,
+            identifier: identifier,
+            contractURI: contractURI
+        )
+    }
+
+    /// Retrieves identifying information about an EVM contract related to bridge onboarding.
+    ///
+    /// @param evmContractAddress: The EVM contract address to retrieve onboarding values for
+    ///
+    /// @return The EVMOnboardingValues struct containing the asset's name, symbol, decimals, contractURI, and
+    ///    Cadence contract name as well as whether the asset is an ERC721
+    ///
+    access(all)
+    fun getEVMOnboardingValues(evmContractAddress: EVM.EVMAddress): EVMOnboardingValues {
+        // Retrieve the EVM contract's name, symbol, and contractURI
+        let name: String = self.getName(evmContractAddress: evmContractAddress)
+        let symbol: String = self.getSymbol(evmContractAddress: evmContractAddress)
+        let contractURI = self.getContractURI(evmContractAddress: evmContractAddress)
+        // Default to 18 decimals for ERC20s
+        var decimals: UInt8 = FlowEVMBridgeConfig.defaultDecimals
+
+        // Derive Cadence contract name
+        let isERC721: Bool = self.isERC721(evmContractAddress: evmContractAddress)
+        var cadenceContractName: String = ""
+        if isERC721 {
+            // Assert the contract is not mixed asset
+            let isERC20 = self.isERC20(evmContractAddress: evmContractAddress)
+            assert(!isERC20, message: "Contract is mixed asset and is not currently supported by the bridge")
+            // Derive the contract name from the ERC721 contract
+            cadenceContractName = self.deriveBridgedNFTContractName(from: evmContractAddress)
+        } else {
+            // Otherwise, treat as ERC20
+            let isERC20 = self.isERC20(evmContractAddress: evmContractAddress)
+            assert(
+                isERC20,
+                message: "Contract \(evmContractAddress.toString())defines an asset that is not currently supported by the bridge"
+            )
+            cadenceContractName = self.deriveBridgedTokenContractName(from: evmContractAddress)
+            decimals = self.getTokenDecimals(evmContractAddress: evmContractAddress)
+        }
+
+        return EVMOnboardingValues(
+            evmContractAddress: evmContractAddress,
+            name: name,
+            symbol: symbol,
+            decimals: decimals,
+            contractURI: contractURI,
+            cadenceContractName: cadenceContractName,
+            isERC721: isERC721
+        )
+    }
+
+    /// Retrieves the EVMPointer view from a given type's defining contract if the view is supported.
+    /// NOTE: This does not guarantee the association is valid, only that the defining Cadence contract declares
+    /// the association.
+    ///
+    /// @param from: The type for which to retrieve the EVMPointer view
+    ///
+    /// @return The resolved EVMPointer view for the given type or nil if the view is unsupported
+    ///
+    access(all)
+    fun getEVMPointerView(forType: Type): CrossVMMetadataViews.EVMPointer? {
+        let contractAddress = forType.address!
+        let contractName = forType.contractName!
+        if let viewResolver = getAccount(contractAddress).contracts.borrow<&{ViewResolver}>(name: contractName) {
+            return viewResolver.resolveContractView(
+                resourceType: forType,
+                viewType: Type<CrossVMMetadataViews.EVMPointer>()
+            ) as? CrossVMMetadataViews.EVMPointer? ?? nil
+        }
+        return nil
+    }
+
+    /************************
+        EVM Call Wrappers
+     ************************/
+
+    /// Retrieves the NFT/FT name from the given EVM contract address - applies for both ERC20 & ERC721.
+    /// Reverts on EVM call failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to retrieve the name from
+    ///
+    /// @return the name of the asset
+    ///
+    access(all)
+    fun getName(evmContractAddress: EVM.EVMAddress): String {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "name()",
+            targetEVMAddress: evmContractAddress,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<String>()]
+        )
+
+        assert(callResult.status == EVM.Status.successful, message: "Call for EVM asset name failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+
+        return callResult.results[0] as! String
+    }
+
+    /// Retrieves the NFT/FT symbol from the given EVM contract address - applies for both ERC20 & ERC721
+    /// Reverts on EVM call failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to retrieve the symbol from
+    ///
+    /// @return the symbol of the asset
+    ///
+    access(all)
+    fun getSymbol(evmContractAddress: EVM.EVMAddress): String {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "symbol()",
+            targetEVMAddress: evmContractAddress,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<String>()]
+        )
+        assert(callResult.status == EVM.Status.successful, message: "Call for EVM asset symbol failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+        return callResult.results[0] as! String
+    }
+
+    /// Retrieves the tokenURI for the given NFT ID from the given EVM contract address. Reverts on EVM call failure.
+    /// Reverts on EVM call failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to retrieve the tokenURI from
+    /// @param id: The ID of the NFT for which to retrieve the tokenURI value
+    ///
+    /// @return the tokenURI of the ERC721
+    ///
+    access(all)
+    fun getTokenURI(evmContractAddress: EVM.EVMAddress, id: UInt256): String {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "tokenURI(uint256)",
+            targetEVMAddress: evmContractAddress,
+            args: [id],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<String>()]
+        )
+
+        assert(callResult.status == EVM.Status.successful, message: "Call to EVM for tokenURI failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+
+        return callResult.results[0] as! String
+    }
+
+    /// Retrieves the contract URI from the given EVM contract address. Returns nil on EVM call failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to retrieve the contractURI from
+    ///
+    /// @return the contract's contractURI
+    ///
+    access(all)
+    fun getContractURI(evmContractAddress: EVM.EVMAddress): String? {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "contractURI()",
+            targetEVMAddress: evmContractAddress,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<String>()]
+        )
+        if callResult.status != EVM.Status.successful {
+            return nil
+        }
+        return callResult.results.length == 1 ? callResult.results[0] as! String : nil
+    }
+
+    /// Retrieves the number of decimals for a given ERC20 contract address. Reverts on EVM call failure.
+    ///
+    /// @param evmContractAddress: The ERC20 contract address to retrieve the token decimals from
+    ///
+    /// @return the token decimals of the ERC20
+    ///
+    access(all)
+    fun getTokenDecimals(evmContractAddress: EVM.EVMAddress): UInt8 {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "decimals()",
+            targetEVMAddress: evmContractAddress,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<UInt8>()]
+        )
+
+        assert(callResult.status == EVM.Status.successful, message: "Call for EVM asset decimals failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+
+        return callResult.results[0] as! UInt8
+    }
+
+    /// Determines if the provided owner address is either the owner or approved for the NFT in the ERC721 contract
+    /// Reverts on EVM call failure.
+    ///
+    /// @param ofNFT: The ID of the NFT to query
+    /// @param owner: The owner address to query
+    /// @param evmContractAddress: The ERC721 contract address to query
+    ///
+    /// @return true if the owner is either the owner or approved for the NFT, false otherwise
+    ///
+    access(all)
+    fun isOwnerOrApproved(ofNFT: UInt256, owner: EVM.EVMAddress, evmContractAddress: EVM.EVMAddress): Bool {
+        return self.isOwner(ofNFT: ofNFT, owner: owner, evmContractAddress: evmContractAddress) ||
+            self.isApproved(ofNFT: ofNFT, owner: owner, evmContractAddress: evmContractAddress)
+    }
+
+    /// Returns whether the given owner is the owner of the given NFT. Reverts on EVM call failure.
+    ///
+    /// @param ofNFT: The ID of the NFT to query
+    /// @param owner: The owner address to query
+    /// @param evmContractAddress: The ERC721 contract address to query
+    ///
+    /// @return true if the owner is in fact the owner of the NFT, false otherwise
+    ///
+    access(all)
+    fun isOwner(ofNFT: UInt256, owner: EVM.EVMAddress, evmContractAddress: EVM.EVMAddress): Bool {
+        return self.ownerOf(id: ofNFT, evmContractAddress: evmContractAddress)?.equals(owner) ?? false
+    }
+
+    /// Returns the owner of a given ERC721 token
+    ///
+    /// @param id: The ID of the NFT to query
+    /// @param evmContractAddress: The ERC721 contract address to query
+    ///
+    /// @return The current owner's EVM address or nil if the `ownerOf` call is unsuccessful
+    /// 
+    access(all)
+    fun ownerOf(id: UInt256, evmContractAddress: EVM.EVMAddress): EVM.EVMAddress? {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "ownerOf(uint256)",
+            targetEVMAddress: evmContractAddress,
+            args: [id],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<EVM.EVMAddress>()]
+        )
+        if callResult.status == EVM.Status.failed {
+            return nil
+        }
+        return callResult.results.length == 1 ? callResult.results[0] as! EVM.EVMAddress : nil
+    }
+
+    /// Returns whether the given owner is approved for the given NFT. Reverts on EVM call failure.
+    ///
+    /// @param ofNFT: The ID of the NFT to query
+    /// @param owner: The owner address to query
+    /// @param evmContractAddress: The ERC721 contract address to query
+    ///
+    /// @return true if the owner is in fact approved for the NFT, false otherwise
+    ///
+    access(all)
+    fun isApproved(ofNFT: UInt256, owner: EVM.EVMAddress, evmContractAddress: EVM.EVMAddress): Bool {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "getApproved(uint256)",
+            targetEVMAddress: evmContractAddress,
+            args: [ofNFT],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<EVM.EVMAddress>()]
+        )
+        assert(callResult.status == EVM.Status.successful, message: "Call to ERC721.getApproved(uint256) failed")
+        if callResult.results.length == 1 {
+            let actualApproved = callResult.results[0] as! EVM.EVMAddress
+            return actualApproved.equals(owner)
+        }
+        return false
+    }
+
+    /// Returns whether the given ERC721 exists, assuming the ERC721 contract implements the `exists` method. While this
+    /// method is not part of the ERC721 standard, it is implemented in the bridge-deployed ERC721 implementation.
+    /// Reverts on EVM call failure.
+    ///
+    /// @param erc721Address: The EVM contract address of the ERC721 token
+    /// @param id: The ID of the ERC721 token to check
+    ///
+    /// @return true if the ERC721 token exists, false otherwise
+    ///
+    access(all)
+    fun erc721Exists(erc721Address: EVM.EVMAddress, id: UInt256): Bool {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "exists(uint256)",
+            targetEVMAddress: erc721Address,
+            args: [id],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<Bool>()]
+        )
+        assert(callResult.results.length == 1, message: "Invalid response length")
+        return callResult.results[0] as! Bool
+    }
+
+    /// Returns the ERC20 balance of the owner at the given ERC20 contract address. Reverts on EVM call failure.
+    ///
+    /// @param owner: The owner address to query
+    /// @param evmContractAddress: The ERC20 contract address to query
+    ///
+    /// @return The UInt256 balance of the owner at the ERC20 contract address. Callers may wish to convert the return
+    ///     value to a UFix64 via convertERC20AmountToCadenceAmount, though note there may be a loss of precision.
+    ///
+    access(all)
+    fun balanceOf(owner: EVM.EVMAddress, evmContractAddress: EVM.EVMAddress): UInt256 {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "balanceOf(address)",
+            targetEVMAddress: evmContractAddress,
+            args: [owner],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<UInt256>()]
+        )
+        assert(callResult.status == EVM.Status.successful, message: "Call to ERC20.balanceOf(address) failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+        return callResult.results[0] as! UInt256
+    }
+
+    /// Determines if the owner has sufficient funds to bridge the given amount at the ERC20 contract address
+    /// Reverts on EVM call failure.
+    ///
+    /// @param amount: The amount to check if the owner has enough balance to cover
+    /// @param owner: The owner address to query
+    /// @param evmContractAddress: The ERC20 contract address to query
+    ///
+    /// @return true if the owner's balance >= amount, false otherwise
+    ///
+    access(all)
+    fun hasSufficientBalance(amount: UInt256, owner: EVM.EVMAddress, evmContractAddress: EVM.EVMAddress): Bool {
+        return self.balanceOf(owner: owner, evmContractAddress: evmContractAddress) >= amount
+    }
+
+    /// Retrieves the total supply of the ERC20 contract at the given EVM contract address. Reverts on EVM call failure.
+    ///
+    /// @param evmContractAddress: The EVM contract address to retrieve the total supply from
+    ///
+    /// @return the total supply of the ERC20
+    ///
+    access(all)
+    fun totalSupply(evmContractAddress: EVM.EVMAddress): UInt256 {
+        let callResult = self.dryCallWithSigAndArgs(
+            signature: "totalSupply()",
+            targetEVMAddress: evmContractAddress,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<UInt256>()]
+        )
+        assert(callResult.status == EVM.Status.successful, message: "Call to ERC20.totalSupply() failed")
+        assert(callResult.results.length == 1, message: "Invalid response length")
+        return callResult.results[0] as! UInt256
+    }
+
+    /// Converts the given amount of ERC20 tokens to the equivalent amount in FLOW tokens based on the ERC20s decimals
+    /// value. Note that may be some loss of decimal precision as UFix64 supports precision for 8 decimal places.
+    /// Reverts on EVM call failure.
+    ///
+    /// @param amount: The amount of ERC20 tokens to convert
+    /// @param erc20Address: The EVM contract address of the ERC20 token
+    ///
+    /// @return the equivalent amount in FLOW tokens as a UFix64
+    ///
+    access(all)
+    fun convertERC20AmountToCadenceAmount(_ amount: UInt256, erc20Address: EVM.EVMAddress): UFix64 {
+        return self.uint256ToUFix64(
+            value: amount,
+            decimals: self.getTokenDecimals(evmContractAddress: erc20Address)
+        )
+    }
+
+    /// Converts the given amount of Cadence fungible tokens to the equivalent amount in ERC20 tokens based on the
+    /// ERC20s decimals. Note that there may be some loss of decimal precision as UFix64 supports precision for 8
+    /// decimal places. Reverts on EVM call failure.
+    ///
+    /// @param amount: The amount of Cadence fungible tokens to convert
+    /// @param erc20Address: The EVM contract address of the ERC20 token
+    ///
+    /// @return the equivalent amount in ERC20 tokens as a UInt256
+    ///
+    access(all)
+    fun convertCadenceAmountToERC20Amount(_ amount: UFix64, erc20Address: EVM.EVMAddress): UInt256 {
+        return self.ufix64ToUInt256(value: amount, decimals: self.getTokenDecimals(evmContractAddress: erc20Address))
+    }
+
+    /// Converts the given ERC20 amount to the corresponding ERC20 amount after rounding down to the maximum precision
+    /// representable by UFix64 (8 decimal places). This ensures that the amount escrowed on the EVM side matches
+    /// exactly the amount that will be minted or unlocked on the Cadence side, preventing sub-UFix64-precision
+    /// "dust" from being permanently locked in escrow without a corresponding Cadence representation.
+    ///
+    /// @param amount: The UInt256 ERC20 amount to cast to Cadence precision
+    /// @param erc20Address: The EVM contract address of the ERC20 token
+    ///
+    /// @return The ERC20 UInt256 amount corresponding to the truncated Cadence UFix64 amount
+    ///
+    access(all)
+    fun castERC20AmountToCadencePrecision(_ amount: UInt256, erc20Address: EVM.EVMAddress): UInt256 {
+        let decimals = self.getTokenDecimals(evmContractAddress: erc20Address)
+        let ufixAmount = self.uint256ToUFix64(value: amount, decimals: decimals)
+        return self.ufix64ToUInt256(value: ufixAmount, decimals: decimals)
+    }
+
+    /// Gets the declared Cadence contract address declared by an EVM contract in conformance to the ICrossVM.sol
+    /// contract interface. Reverts if the EVM call is unsuccessful.
+    /// NOTE: Just because an EVM contract declares an association does not mean it it is valid!
+    ///
+    /// @param evmContract: The ICrossVM.sol conforming EVM contract from which to retrieve the declared Cadence
+    ///     contract address
+    ///
+    /// @return The resulting Cadence Address as declared associated by the provided EVM contract or nil if the call fails
+    ///
+    access(all)
+    fun getDeclaredCadenceAddressFromCrossVM(evmContract: EVM.EVMAddress): Address? {
+        let cadenceAddrRes = self.dryCallWithSigAndArgs(
+            signature: "getCadenceAddress()",
+            targetEVMAddress: evmContract,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<String>()]
+        )
+        if cadenceAddrRes.status != EVM.Status.successful {
+            return nil
+        }
+        assert(cadenceAddrRes.results.length == 1, message: "Invalid response length")
+        var cadenceAddrStr = cadenceAddrRes.results[0] as! String
+        if cadenceAddrStr[1] != "x" {
+            cadenceAddrStr = "0x\(cadenceAddrStr)"
+        }
+        return Address.fromString(cadenceAddrStr) ?? nil
+    }
+
+    /// Gets the declared Cadence Type declared by an EVM contract in conformance to the ICrossVM.sol contract
+    /// interface. Reverts if the EVM call is unsuccessful.
+    /// NOTE: Just because an EVM contract declares an association does not mean it it is valid!
+    ///
+    /// @param evmContract: The ICrossVM.sol conforming EVM contract from which to retrieve the declared Cadence
+    ///     Type
+    ///
+    /// @return The resulting Cadence Type as declared associated by the provided EVM contract or nil if the call fails
+    ///
+    ///
+    access(all)
+    fun getDeclaredCadenceTypeFromCrossVM(evmContract: EVM.EVMAddress): Type? {
+        let cadenceIdentifierRes = self.dryCallWithSigAndArgs(
+            signature: "getCadenceIdentifier()",
+            targetEVMAddress: evmContract,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<String>()]
+        )
+        if cadenceIdentifierRes.status != EVM.Status.successful {
+            return nil
+        }
+        assert(cadenceIdentifierRes.results.length == 1, message: "Invalid response length")
+        let cadenceIdentifier = cadenceIdentifierRes.results[0] as! String
+        return CompositeType(cadenceIdentifier) ?? nil
+    }
+
+    /// Returns whether the provided EVM contract conforms to ICrossVMBridgeERC721Fulfillment.sol contract interface.
+    /// Doing so is one of two interfaces that must be implemented for Cadence-native cross-VM NFTs to be successfully
+    /// registered
+    ///
+    /// @param evmContract: The EVM contract to check for ICrossVMBridgeERC721 conformance
+    ///
+    /// @return True if conformance is found, false otherwise
+    ///
+    access(all)
+    fun supportsICrossVMBridgeERC721Fulfillment(evmContract: EVM.EVMAddress): Bool {
+        let interfaceID = EVM.EVMBytes4(value: "2e608d70".decodeHex().toConstantSized<[UInt8; 4]>()!)
+        let supportsRes = self.dryCallWithSigAndArgs(
+            signature: "supportsInterface(bytes4)",
+            targetEVMAddress: evmContract,
+            args: [interfaceID],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<Bool>()]
+        )
+        if supportsRes.status != EVM.Status.successful {
+            return false
+        }
+        if supportsRes.results.length != 1 {
+            return false
+        }
+        return supportsRes.results[0] as! Bool
+    }
+
+    /// Returns whether the provided EVM contract conforms to ICrossVMBridgeCallable.sol contract interface.
+    /// Doing so is one of two interfaces that must be implemented for Cadence-native cross-VM NFTs to be successfully
+    /// registered
+    ///
+    /// @param evmContract: The EVM contract to check for ICrossVMBridgeCallable conformance
+    ///
+    /// @return True if conformance is found, false otherwise
+    ///
+    access(all)
+    fun supportsICrossVMBridgeCallable(evmContract: EVM.EVMAddress): Bool {
+        let interfaceID = EVM.EVMBytes4(value: "b7f9a9ec".decodeHex().toConstantSized<[UInt8; 4]>()!)
+        let supportsRes = self.dryCallWithSigAndArgs(
+            signature: "supportsInterface(bytes4)",
+            targetEVMAddress: evmContract,
+            args: [interfaceID],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<Bool>()]
+        )
+        if supportsRes.status != EVM.Status.successful {
+            return false
+        }
+        if supportsRes.results.length != 1 {
+            return false
+        }
+        return supportsRes.results[0] as! Bool
+    }
+
+    /// Returns whether the provided EVM contract conforms to both ICrossVMBridgeERC721Fulfillment and
+    /// ICrossVMBridgeCallable Solidity contract interfaces
+    ///
+    /// @param evmContract: The EVM contract to check for conformance
+    ///
+    /// @return True if conformance is found, false otherwise
+    ///
+    access(all)
+    fun supportsCadenceNativeNFTEVMInterfaces(evmContract: EVM.EVMAddress): Bool {
+        return self.supportsICrossVMBridgeCallable(evmContract: evmContract)
+            && self.supportsICrossVMBridgeERC721Fulfillment(evmContract: evmContract)
+    }
+
+    /// Returns the VM Bridge address designated by the ICrossVMBridgeCallable conforming EVM contract. Reverts on call
+    /// failure.
+    ///
+    /// @param evmContract: The ICrossVMBridgeCallable EVM contract from which to retrieve the value
+    ///
+    /// @return The EVM address designated as the VM bridge address in the provided contract
+    ///
+    access(all)
+    fun getVMBridgeAddressFromICrossVMBridgeCallable(evmContract: EVM.EVMAddress): EVM.EVMAddress? {
+        let cadenceIdentifierRes = self.dryCallWithSigAndArgs(
+            signature: "vmBridgeAddress()",
+            targetEVMAddress: evmContract,
+            args: [],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<EVM.EVMAddress>()]
+        )
+        if cadenceIdentifierRes.status != EVM.Status.successful {
+            return nil
+        }
+        return cadenceIdentifierRes.results.length == 1 ? cadenceIdentifierRes.results[0] as! EVM.EVMAddress : nil
+    }
+
+    /************************
+        Derivation Utils
+     ************************/
+
+    /// Derives the StoragePath where the escrow locker is stored for a given Type of asset & returns. The given type
+    /// must be of an asset supported by the bridge.
+    ///
+    /// @param fromType: The type of the asset the escrow locker is being derived for
+    ///
+    /// @return The StoragePath associated with the type's escrow Locker, or nil if the type is not supported
+    ///
+    access(all)
+    view fun deriveEscrowStoragePath(fromType: Type): StoragePath? {
+        if !self.isValidCadenceAsset(type: fromType) {
+            return nil
+        }
+        var prefix = ""
+        if fromType.isSubtype(of: Type<@{NonFungibleToken.NFT}>()) {
+            prefix = "flowEVMBridgeNFTEscrow"
+        } else if fromType.isSubtype(of: Type<@{FungibleToken.Vault}>()) {
+            prefix = "flowEVMBridgeTokenEscrow"
+        }
+        assert(prefix.length > 1, message: "Invalid prefix")
+        if let splitIdentifier = self.splitObjectIdentifier(identifier: fromType.identifier) {
+            let sourceContractAddress = Address.fromString("0x\(splitIdentifier[1])")!
+            let sourceContractName = splitIdentifier[2]
+            let resourceName = splitIdentifier[3]
+            return StoragePath(
+                identifier: "\(prefix)\(self.delimiter)\(sourceContractAddress.toString())\(self.delimiter)\(sourceContractName)\(self.delimiter)\(resourceName)"
+            ) ?? nil
+        }
+        return nil
+    }
+
+    /// Derives the Cadence contract name for a given EVM NFT of the form
+    /// EVMVMBridgedNFT_<0xCONTRACT_ADDRESS>
+    ///
+    /// @param from evmContract: The EVM contract address to derive the Cadence NFT contract name for
+    ///
+    /// @return The derived Cadence FT contract name
+    ///
+    access(all)
+    view fun deriveBridgedNFTContractName(from evmContract: EVM.EVMAddress): String {
+        return "\(self.contractNamePrefixes[Type<@{NonFungibleToken.NFT}>()]!["bridged"]!)\(self.delimiter)\(evmContract.toString())"
+    }
+
+    /// Derives the Cadence contract name for a given EVM fungible token of the form
+    /// EVMVMBridgedToken_<0xCONTRACT_ADDRESS>
+    ///
+    /// @param from evmContract: The EVM contract address to derive the Cadence FT contract name for
+    ///
+    /// @return The derived Cadence FT contract name
+    ///
+    access(all)
+    view fun deriveBridgedTokenContractName(from evmContract: EVM.EVMAddress): String {
+        return "\(self.contractNamePrefixes[Type<@{FungibleToken.Vault}>()]!["bridged"]!)\(self.delimiter)\(evmContract.toString())"
+    }
+
+    /****************
+        Math Utils
+     ****************/
+
+    /// Raises the base to the power of the exponent
+    ///
+    access(all)
+    view fun pow(base: UInt256, exponent: UInt8): UInt256 {
+        if exponent == 0 {
+            return 1
+        }
+
+        var r = base
+        var exp: UInt8 = 1
+        while exp < exponent {
+            r = r * base
+            exp = exp + 1
+        }
+
+        return r
+    }
+
+    /// Raises the fixed point base to the power of the exponent
+    ///
+    access(all)
+    view fun ufixPow(base: UFix64, exponent: UInt8): UFix64 {
+        if exponent == 0 {
+            return 1.0
+        }
+
+        var r = base
+        var exp: UInt8 = 1
+        while exp < exponent {
+            r = r * base
+            exp = exp + 1
+        }
+
+        return r
+    }
+
+    /// Converts a UFix64 to a UInt256
+    ///
+    /// Note on overflow safety: `integer * integerMultiplier` where `integerMultiplier = 10^decimals` could
+    /// theoretically overflow UInt256 for very large `decimals` values (e.g. decimals > ~58 with a non-zero
+    /// integer part). In practice this is not a concern: ERC20 tokens with more than 18 decimals are outside
+    /// the ERC20 standard convention, and UFix64.max (~1.84e19) * 10^18 ≈ 1.84e37, well within UInt256 range.
+    /// The bridge sources `decimals` from on-chain ERC20 `decimals()` calls; a malicious token reporting
+    /// extreme decimals would only affect its own bridged representation, not other assets.
+    //
+    access(all)
+    view fun ufix64ToUInt256(value: UFix64, decimals: UInt8): UInt256 {
+        // Default to 10e8 scale, catching instances where decimals are less than default and scale appropriately
+        let ufixScaleExp: UInt8 = decimals < 8 ? decimals : 8
+        var ufixScale = self.ufixPow(base: 10.0, exponent: ufixScaleExp)
+
+        // Separate the fractional and integer parts of the UFix64
+        let integer = UInt256(value)
+        var fractional = (value % 1.0) * ufixScale
+
+        // Calculate the multiplier for integer and fractional parts
+        var integerMultiplier: UInt256 = self.pow(base:10, exponent: decimals)
+        let fractionalMultiplierExp: UInt8 = decimals < 8 ? 0 : decimals - 8
+        var fractionalMultiplier: UInt256 = self.pow(base:10, exponent: fractionalMultiplierExp)
+
+        // Scale and sum the parts
+        return integer * integerMultiplier + UInt256(fractional) * fractionalMultiplier
+    }
+
+    /// Converts a UInt256 to a UFix64
+    ///
+    access(all)
+    view fun uint256ToUFix64(value: UInt256, decimals: UInt8): UFix64 {
+        // Calculate scale factors for the integer and fractional parts
+        let absoluteScaleFactor = self.pow(base: 10, exponent: decimals)
+
+        // Separate the integer and fractional parts of the value
+        let scaledValue = value / absoluteScaleFactor
+        var fractional = value % absoluteScaleFactor
+        // Scale the fractional part
+        let scaledFractional = self.uint256FractionalToScaledUFix64Decimals(value: fractional, decimals: decimals)
+
+        // Ensure the parts do not exceed the max UFix64 value before conversion
+        assert(
+            scaledValue <= UInt256(UFix64.max),
+            message: "Scaled integer value \(value.toString()) exceeds max UFix64 value"
+        )
+        /// Check for the max value that can be converted to a UFix64 without overflowing
+        assert(
+            scaledValue == UInt256(UFix64.max) ? scaledFractional < 0.09551616 : true,
+            message: "Scaled integer value \(value.toString()) exceeds max UFix64 value"
+        )
+
+        return UFix64(scaledValue) + scaledFractional
+    }
+
+    /// Converts a UInt256 fractional value with the given decimal places to a scaled UFix64. Note that UFix64 has
+    /// decimal precision of 8 places so converted values may lose precision and be rounded down.
+    ///
+    access(all)
+    view fun uint256FractionalToScaledUFix64Decimals(value: UInt256, decimals: UInt8): UFix64 {
+        pre {
+            self.getNumberOfDigits(value) <= decimals: "Fractional digits exceed the defined decimal places"
+        }
+        post {
+            result < 1.0: "Resulting scaled fractional exceeds 1.0"
+        }
+
+        var fractional = value
+        // Truncate fractional to the first 8 decimal places which is the max precision for UFix64
+        if decimals >= 8 {
+            fractional = fractional / self.pow(base: 10, exponent: decimals - 8)
+        }
+        // Return early if the truncated fractional part is now 0
+        if fractional == 0 {
+            return 0.0
+        }
+
+        // Scale the fractional part
+        let fractionalMultiplier = self.ufixPow(base: 0.1, exponent: decimals < 8 ? decimals : 8)
+        return UFix64(fractional) * fractionalMultiplier
+    }
+
+    /// Returns the value as a UInt64 if it fits, otherwise panics
+    ///
+    access(all)
+    view fun uint256ToUInt64(value: UInt256): UInt64 {
+        return value <= UInt256(UInt64.max) ? UInt64(value) : panic("Value too large to fit into UInt64")
+    }
+
+    /// Returns the number of digits in the given UInt256
+    ///
+    access(all)
+    view fun getNumberOfDigits(_ value: UInt256): UInt8 {
+        var tmp = value
+        var digits: UInt8 = 0
+        while tmp > 0 {
+            tmp = tmp / 10
+            digits = digits + 1
+        }
+        return digits
+    }
+
+    /***************************
+        Type Identifier Utils
+     ***************************/
+
+    /// Returns the contract address from the given Type
+    ///
+    /// @param fromType: The Type to extract the contract address from
+    ///
+    /// @return The defining contract's Address, or nil if the identifier does not have an associated Address
+    ///
+    access(all)
+    view fun getContractAddress(fromType: Type): Address? {
+        return fromType.address
+    }
+
+    /// Returns the defining contract name from the given Type
+    ///
+    /// @param fromType: The Type to extract the contract name from
+    ///
+    /// @return The defining contract's name, or nil if the identifier does not have an associated contract name
+    ///
+    access(all)
+    view fun getContractName(fromType: Type): String? {
+        return fromType.contractName
+    }
+
+    /// Returns the object's name from the given Type's identifier where the identifier is in the format
+    /// of: A.<CONTRACT_ADDRESS_SANS_0x>.<CONTRACT_NAME>.<OBJECT_NAME>
+    ///
+    /// @param fromType: The Type to extract the object name from
+    ///
+    /// @return The object's name, or nil if the identifier does identify an object
+    ///
+    access(all)
+    view fun getObjectName(fromType: Type): String? {
+        if let identifierSplit = self.splitObjectIdentifier(identifier: fromType.identifier) {
+            return identifierSplit[3]
+        }
+        return nil
+    }
+
+    /// Splits the given identifier into its constituent parts defined by a delimiter of '".'"
+    ///
+    /// @param identifier: The identifier to split
+    ///
+    /// @return An array of the identifier's constituent parts, or nil if the identifier does not have 4 parts
+    ///
+    access(all)
+    view fun splitObjectIdentifier(identifier: String): [String]? {
+        let identifierSplit = identifier.split(separator: ".")
+        return identifierSplit.length != 4 ? nil : identifierSplit
+    }
+
+    /// Builds a composite type from the given identifier parts
+    ///
+    /// @param address: The defining contract address
+    /// @param contractName: The defining contract name
+    /// @param resourceName: The resource name
+    ///
+    access(all)
+    view fun buildCompositeType(address: Address, contractName: String, resourceName: String): Type? {
+        let addressStr = address.toString()
+        let subtract0x = addressStr.slice(from: 2, upTo: addressStr.length)
+        let identifier = "A.\(subtract0x).\(contractName).\(resourceName)"
+        return CompositeType(identifier)
+    }
+
+    /**************************
+        FungibleToken Utils
+     **************************/
+
+    /// Returns the `createEmptyVault()` function from a Vault Type's defining contract or nil if either the Type is not
+    access(all) fun getCreateEmptyVaultFunction(forType: Type): (fun (Type): @{FungibleToken.Vault})? {
+        // We can only reasonably assume that the requested function is accessible from a FungibleToken contract
+        if !forType.isSubtype(of: Type<@{FungibleToken.Vault}>()) {
+            return nil
+        }
+        // Vault Types should guarantee that the following forced optionals are safe
+        let contractAddress = self.getContractAddress(fromType: forType)!
+        let contractName = self.getContractName(fromType: forType)!
+        let tokenContract: &{FungibleToken} = getAccount(contractAddress).contracts.borrow<&{FungibleToken}>(
+                name: contractName
+            )!
+        return tokenContract.createEmptyVault
+    }
+
+    /******************************
+        Bridge-Access Only Utils
+     ******************************/
+
+    /// Deposits fees to the bridge account's FlowToken Vault - helps fund asset storage
+    ///
+    access(account)
+    fun depositFee(_ feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}, feeAmount: UFix64) {
+        let vault = self.account.storage.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
+            ?? panic("Could not borrow FlowToken.Vault reference")
+
+        let feeVault <-feeProvider.withdraw(amount: feeAmount) as! @FlowToken.Vault
+        assert(feeVault.balance == feeAmount, message: "Fee provider did not return the requested fee")
+
+        vault.deposit(from: <-feeVault)
+    }
+
+    /// Enables other bridge contracts to orchestrate bridge operations from contract-owned COA
+    ///
+    access(account)
+    view fun borrowCOA(): auth(EVM.Call, EVM.Withdraw) &EVM.CadenceOwnedAccount {
+        return self.account.storage.borrow<auth(EVM.Call, EVM.Withdraw) &EVM.CadenceOwnedAccount>(
+            from: FlowEVMBridgeConfig.coaStoragePath
+        ) ?? panic("Could not borrow COA reference")
+    }
+
+    /// Shared helper simplifying calls using the bridge account's COA
+    ///
+    access(account)
+    fun callWithSigAndArgs(
+        signature: String,
+        targetEVMAddress: EVM.EVMAddress,
+        args: [AnyStruct],
+        gasLimit: UInt64,
+        value: UFix64,
+        resultTypes: [Type]?
+    ): EVM.ResultDecoded {
+        var valueBalance: UInt = 0
+        if value > 0.0 {
+            let balance = EVM.Balance(attoflow: 0)
+            balance.setFLOW(flow: value)
+            valueBalance = balance.inAttoFLOW()
+        }
+
+        return self.borrowCOA().callWithSigAndArgs(
+            to: targetEVMAddress,
+            signature: signature,
+            args: args,
+            gasLimit: gasLimit,
+            value: valueBalance,
+            resultTypes: resultTypes
+        )
+    }
+
+    /// Shared helper simplifying dryCalls using the bridge account's COA. Note that `COA.dryCall` does not execute the
+    /// call within EVM, serving solely as a mechanism for retrieving data from Flow-EVM environment.
+    ///
+    access(account)
+    fun dryCallWithSigAndArgs(
+        signature: String,
+        targetEVMAddress: EVM.EVMAddress,
+        args: [AnyStruct],
+        gasLimit: UInt64,
+        value: UFix64,
+        resultTypes: [Type]?
+    ): EVM.ResultDecoded {
+        var valueBalance: UInt = 0
+        if value > 0.0 {
+            let balance = EVM.Balance(attoflow: 0)
+            balance.setFLOW(flow: value)
+            valueBalance = balance.inAttoFLOW()
+        }
+
+        return self.borrowCOA().dryCallWithSigAndArgs(
+            to: targetEVMAddress,
+            signature: signature,
+            args: args,
+            gasLimit: gasLimit,
+            value: valueBalance,
+            resultTypes: resultTypes
+        )
+    }
+
+    /// Executes a safeTransferFrom call on the given ERC721 contract address, transferring the NFT from bridge escrow
+    /// in EVM to the named recipient and asserting pre- and post-state changes.
+    ///
+    access(account)
+    fun mustSafeTransferERC721(erc721Address: EVM.EVMAddress, to: EVM.EVMAddress, id: UInt256) {
+        let bridgeCOAAddress = self.getBridgeCOAEVMAddress()
+
+        let bridgePreStatus = self.isOwner(ofNFT: id, owner: bridgeCOAAddress, evmContractAddress: erc721Address)
+        let toPreStatus = self.isOwner(ofNFT: id, owner: to, evmContractAddress: erc721Address)
+        assert(bridgePreStatus, message: "Bridge COA does not own ERC721 requesting to be transferred")
+        assert(!toPreStatus, message: "Recipient already owns ERC721 attempting to be transferred")
+
+        let transferResult = self.callWithSigAndArgs(
+            signature: "safeTransferFrom(address,address,uint256)",
+            targetEVMAddress: erc721Address,
+            args: [bridgeCOAAddress, to, id],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(
+            transferResult.status == EVM.Status.successful,
+            message: "safeTransferFrom call to ERC721 transferring NFT from escrow to bridge recipient failed"
+        )
+
+        let bridgePostStatus = self.isOwner(ofNFT: id, owner: bridgeCOAAddress, evmContractAddress: erc721Address)
+        let toPostStatus = self.isOwner(ofNFT: id, owner: to, evmContractAddress: erc721Address)
+        assert(!bridgePostStatus, message: "ERC721 is still in escrow after transfer")
+        assert(toPostStatus, message: "ERC721 was not successfully transferred to recipient from escrow")
+    }
+
+    /// Executes a safeMint call on the given ERC721 contract address, minting an ERC721 to the named recipient and
+    /// asserting pre- and post-state changes. Assumes the bridge COA has the authority to mint the NFT.
+    ///
+    access(account)
+    fun mustSafeMintERC721(erc721Address: EVM.EVMAddress, to: EVM.EVMAddress, id: UInt256, uri: String) {
+        let bridgeCOAAddress = self.getBridgeCOAEVMAddress()
+
+        let mintResult = self.callWithSigAndArgs(
+            signature: "safeMint(address,uint256,string)",
+            targetEVMAddress: erc721Address,
+            args: [to, id, uri],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(mintResult.status == EVM.Status.successful, message: "Mint to bridge recipient failed")
+
+        let toPostStatus = self.isOwner(ofNFT: id, owner: to, evmContractAddress: erc721Address)
+        assert(toPostStatus, message: "Recipient does not own the NFT after minting")
+    }
+
+    /// Executes a safeMint call on the given ERC721 contract address, minting an ERC721 to the named recipient and
+    /// asserting pre- and post-state changes. Assumes the bridge COA has the authority to mint the NFT.
+    ///
+    access(account)
+    fun mustFulfillNFTToEVM(erc721Address: EVM.EVMAddress, to: EVM.EVMAddress, id: UInt256, maybeBytes: EVM.EVMBytes?) {
+        let fulfillResult = self.callWithSigAndArgs(
+            signature: "fulfillToEVM(address,uint256,bytes)",
+            targetEVMAddress: erc721Address,
+            args: [to, id, maybeBytes ?? EVM.EVMBytes(value: [])],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(
+            fulfillResult.status == EVM.Status.successful,
+            message: "Fulfill ERC721 \(erc721Address.toString()) with id \(id) to \(to.toString()) failed with error code \(fulfillResult.errorCode): \(fulfillResult.errorMessage)"
+        )
+
+        let toPostStatus = self.isOwner(ofNFT: id, owner: to, evmContractAddress: erc721Address)
+        assert(toPostStatus, message: "Recipient does not own the NFT after minting")
+    }
+
+    /// Executes updateTokenURI call on the given ERC721 contract address, updating the tokenURI of the NFT. This is
+    /// not a standard ERC721 function, but is implemented in the bridge-deployed ERC721 implementation to enable
+    /// synchronization of token metadata with Cadence NFT state on bridging.
+    ///
+    access(account)
+    fun mustUpdateTokenURI(erc721Address: EVM.EVMAddress, id: UInt256, uri: String) {
+        let bridgeCOAAddress = self.getBridgeCOAEVMAddress()
+
+        let updateResult = self.callWithSigAndArgs(
+            signature: "updateTokenURI(uint256,string)",
+            targetEVMAddress: erc721Address,
+            args: [id, uri],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(updateResult.status == EVM.Status.successful, message: "URI update failed")
+    }
+
+    /// Executes the provided method, assumed to be a protected transfer call, and confirms that the transfer was
+    /// successful by validating the named owner is authorized to act on the NFT before the transfer, the transfer
+    /// was successful, and the bridge COA owns the NFT after the protected transfer call.
+    ///
+    access(account)
+    fun mustEscrowERC721(
+        owner: EVM.EVMAddress,
+        id: UInt256,
+        erc721Address: EVM.EVMAddress,
+        protectedTransferCall: fun (EVM.EVMAddress): EVM.ResultDecoded
+    ) {
+        // Ensure the named owner is authorized to act on the NFT
+        let isAuthorized = self.isOwnerOrApproved(ofNFT: id, owner: owner, evmContractAddress: erc721Address)
+        assert(isAuthorized, message: "Named owner is not the owner of the ERC721")
+
+        // Call the protected transfer function which should execute a transfer call from the owner to escrow
+        let transferResult = protectedTransferCall(erc721Address)
+        assert(transferResult.status == EVM.Status.successful, message: "Transfer ERC721 to escrow via callback failed")
+
+        // Validate the NFT is now owned by the bridge COA, escrow the NFT
+        let isEscrowed = self.isOwner(ofNFT: id, owner: self.getBridgeCOAEVMAddress(), evmContractAddress: erc721Address)
+        assert(isEscrowed, message: "ERC721 was not successfully escrowed")
+    }
+
+    /// Unwraps an ERC721 token, calling `ERC721Wrapper.withdrawTo(address,uint256[])` on the provided wrapper address
+    /// and ensuring that the underlying ERC721 is owned by the bridge COA before returning.
+    /// NOTE: This method relies on implementation of OpenZeppelin's `ERC721Wrapper` contract interface, reverting if
+    /// the unwrap operation is unsuccessful.
+    ///
+    access(account)
+    fun mustUnwrapERC721(
+        id: UInt256,
+        erc721WrapperAddress: EVM.EVMAddress,
+        underlyingEVMAddress: EVM.EVMAddress
+    ) {
+        assert(
+            self.isOwner(ofNFT: id, owner: erc721WrapperAddress, evmContractAddress: underlyingEVMAddress),
+            message: "Attempting to unwrap \(underlyingEVMAddress.toString()) ID \(id), but token is not wrapped by \(erc721WrapperAddress.toString())"
+        )
+        let bridgeCOA = self.getBridgeCOAEVMAddress()
+
+        let unwrapResult = self.callWithSigAndArgs(
+            signature: "withdrawTo(address,uint256[])",
+            targetEVMAddress: erc721WrapperAddress,
+            args: [bridgeCOA, [id]],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(
+            unwrapResult.status == EVM.Status.successful,
+            message: "Call to \(erc721WrapperAddress.toString()) ERC721Wrapper.withdrawTo(address,uint256[]) failed"
+        )
+
+        assert(
+            self.isOwner(ofNFT: id, owner: bridgeCOA, evmContractAddress: underlyingEVMAddress),
+            message: "Unsuccessful escrow of wrapped ERC721 \(erc721WrapperAddress.toString()) wrapping underlying \(underlyingEVMAddress.toString()) ID \(id)"
+        )
+    }
+
+    /// Mints ERC20 tokens to the recipient and confirms that the recipient's balance was updated
+    ///
+    access(account)
+    fun mustMintERC20(to: EVM.EVMAddress, amount: UInt256, erc20Address: EVM.EVMAddress) {
+        let toPreBalance = self.balanceOf(owner: to, evmContractAddress: erc20Address)
+        // Mint tokens to the recipient
+        let mintResult = self.callWithSigAndArgs(
+            signature: "mint(address,uint256)",
+            targetEVMAddress: erc20Address,
+            args: [to, amount],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(mintResult.status == EVM.Status.successful, message: "Mint to bridge ERC20 contract failed")
+        // Ensure bridge to recipient was succcessful
+        let toPostBalance = self.balanceOf(owner: to, evmContractAddress: erc20Address)
+        assert(
+            toPostBalance == toPreBalance + amount,
+            message: "Recipient didn't receive minted ERC20 tokens during bridging"
+        )
+    }
+
+    /// Transfers ERC20 tokens to the recipient and confirms that the recipient's balance was incremented and the escrow
+    /// balance was decremented by the requested amount.
+    ///
+    access(account)
+    fun mustTransferERC20(to: EVM.EVMAddress, amount: UInt256, erc20Address: EVM.EVMAddress) {
+        let bridgeCOAAddress = self.getBridgeCOAEVMAddress()
+
+        let toPreBalance = self.balanceOf(owner: to, evmContractAddress: erc20Address)
+        let escrowPreBalance = self.balanceOf(
+            owner: bridgeCOAAddress,
+            evmContractAddress: erc20Address
+        )
+
+        // Transfer tokens to the recipient
+        let transferResult = self.callWithSigAndArgs(
+            signature: "transfer(address,uint256)",
+            targetEVMAddress: erc20Address,
+            args: [to, amount],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(transferResult.status == EVM.Status.successful, message: "transfer call to ERC20 contract failed")
+
+        // Ensure bridge to recipient was succcessful
+        let toPostBalance = self.balanceOf(owner: to, evmContractAddress: erc20Address)
+        let escrowPostBalance = self.balanceOf(
+            owner: bridgeCOAAddress,
+            evmContractAddress: erc20Address
+        )
+        assert(
+            toPostBalance == toPreBalance + amount,
+            message: "Recipient's ERC20 balance did not increment by the requested amount after transfer from escrow"
+        )
+        assert(
+            escrowPostBalance == escrowPreBalance - amount,
+            message: "Escrow ERC20 balance did not decrement by the requested amount after transfer from escrow"
+        )
+    }
+
+    /// Executes the provided method, assumed to be a protected transfer call, and confirms that the transfer was
+    /// successful by validating that the named owner's balance was decremented by the requested amount and the bridge
+    /// escrow balance was incremented by the same amount.
+    ///
+    access(account)
+    fun mustEscrowERC20(
+        owner: EVM.EVMAddress,
+        amount: UInt256,
+        erc20Address: EVM.EVMAddress,
+        protectedTransferCall: fun (): EVM.ResultDecoded
+    ) {
+        // Ensure the caller is has sufficient balance to bridge the requested amount
+        let hasSufficientBalance = self.hasSufficientBalance(
+            amount: amount,
+            owner: owner,
+            evmContractAddress: erc20Address
+        )
+        assert(hasSufficientBalance, message: "Caller does not have sufficient balance to bridge requested tokens")
+
+        // Get the owner and escrow balances before transfer
+        let ownerPreBalance = self.balanceOf(owner: owner, evmContractAddress: erc20Address)
+        let bridgePreBalance = self.balanceOf(
+                owner: self.getBridgeCOAEVMAddress(),
+                evmContractAddress: erc20Address
+            )
+
+        // Call the protected transfer function which should execute a transfer call from the owner to escrow
+        let transferResult = protectedTransferCall()
+        assert(transferResult.status == EVM.Status.successful, message: "Transfer via callback failed")
+
+        // Get the resulting balances after transfer
+        let ownerPostBalance = self.balanceOf(owner: owner, evmContractAddress: erc20Address)
+        let bridgePostBalance = self.balanceOf(
+                owner: self.getBridgeCOAEVMAddress(),
+                evmContractAddress: erc20Address
+            )
+
+        // Confirm the expected amount moved from owner to bridge escrow. These post-state assertions are the
+        // primary security guarantee for ERC20 escrow — they catch any accounting discrepancy regardless of
+        // cause (reentrant callbacks, fee-on-transfer tokens, etc.). The pre-balance snapshot above is not a
+        // TOCTOU risk because all EVM calls within a single Cadence transaction execute within the same EVM
+        // block, so no interleaving can occur between the snapshot and the transfer.
+        assert(ownerPostBalance == ownerPreBalance - amount, message: "Transfer to owner failed")
+        assert(bridgePostBalance == bridgePreBalance + amount, message: "Transfer to bridge escrow failed")
+    }
+
+    /// Executes a `burn(uint256)` call targeting the provided ERC721 contract address. Reverts if the call is
+    /// unsuccessful
+    ///
+    access(account)
+    fun mustBurnERC721(erc721Address: EVM.EVMAddress, id: UInt256) {
+        let burnResult = FlowEVMBridgeUtils.callWithSigAndArgs(
+            signature: "burn(uint256)",
+            targetEVMAddress: erc721Address,
+            args: [id],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        )
+        assert(burnResult.status == EVM.Status.successful,
+            message: "0x\(erc721Address.toString()).burn(\(id)) failed with error code \(burnResult.errorCode) and message: \(burnResult.errorMessage)")
+    }
+
+    /// Calls to the bridge factory to deploy an ERC721/ERC20 contract and returns the deployed contract address
+    ///
+    access(account)
+    fun mustDeployEVMContract(
+        name: String,
+        symbol: String,
+        cadenceAddress: Address,
+        flowIdentifier: String,
+        contractURI: String,
+        isERC721: Bool
+    ): EVM.EVMAddress {
+        let deployerTag = isERC721 ? "ERC721" : "ERC20"
+        let deployResult = self.callWithSigAndArgs(
+            signature: "deploy(string,string,string,string,string,string)",
+            targetEVMAddress: self.bridgeFactoryEVMAddress,
+            args: [deployerTag, name, symbol, cadenceAddress.toString(), flowIdentifier, contractURI],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: [Type<EVM.EVMAddress>()]
+        )
+        assert(deployResult.status == EVM.Status.successful, message: "EVM Token contract deployment failed")
+        assert(deployResult.results.length == 1, message: "Invalid response length")
+        return deployResult.results[0] as! EVM.EVMAddress
+    }
+
+    /// Calls `setSymbol(string)` on the EVM contract as exposed on FlowEVMBridgedERC721 contracts, enabling Cadence
+    /// NFTs to update their EVM symbol via EVMBridgedMetadata.symbol. The call's status is returned so conditional 
+    /// execution can be handled on the caller's end.
+    ///
+    access(account)
+    fun tryUpdateSymbol(_ evmContractAddress: EVM.EVMAddress, symbol: String): Bool {
+        return self.callWithSigAndArgs(
+            signature: "setSymbol(string)",
+            targetEVMAddress: evmContractAddress,
+            args: [symbol],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0,
+            resultTypes: nil
+        ).status == EVM.Status.successful
+    }
+
+    init(bridgeFactoryAddressHex: String) {
+        self.delimiter = "_"
+        self.contractNamePrefixes = {
+            Type<@{NonFungibleToken.NFT}>(): {
+                "bridged": "EVMVMBridgedNFT"
+            },
+            Type<@{FungibleToken.Vault}>(): {
+                "bridged": "EVMVMBridgedToken"
+            }
+        }
+        self.bridgeFactoryEVMAddress = EVM.addressFromString(bridgeFactoryAddressHex.toLower())
+    }
+}

--- a/contracts/external/FungibleToken.cdc
+++ b/contracts/external/FungibleToken.cdc
@@ -1,0 +1,297 @@
+/**
+
+# The Flow Fungible Token standard
+
+## `FungibleToken` contract
+
+If a users wants to deploy a new token contract, their contract
+needs to implement the FungibleToken interface and their tokens
+need to implement the interfaces defined in this contract.
+
+/// Contributors (please add to this list if you contribute!):
+/// - Joshua Hannan - https://github.com/joshuahannan
+/// - Bastian Müller - https://twitter.com/turbolent
+/// - Dete Shirley - https://twitter.com/dete73
+/// - Bjarte Karlsen - https://twitter.com/0xBjartek
+/// - Austin Kline - https://twitter.com/austin_flowty
+/// - Giovanni Sanchez - https://twitter.com/gio_incognito
+/// - Deniz Edincik - https://twitter.com/bluesign
+/// - Jonny - https://github.com/dryruner
+///
+/// Repo reference: https://github.com/onflow/flow-ft
+
+## `Vault` resource interface
+
+Each fungible token resource type needs to implement the `Vault` resource interface.
+
+## `Provider`, `Receiver`, and `Balance` resource interfaces
+
+These interfaces declare pre-conditions and post-conditions that restrict
+the execution of the functions in the Vault.
+
+It gives users the ability to make custom resources that implement
+these interfaces to do various things with the tokens.
+For example, a faucet can be implemented by conforming
+to the Provider interface.
+
+*/
+
+import "ViewResolver"
+import "Burner"
+
+/// FungibleToken
+///
+/// Fungible Token implementations should implement the fungible token
+/// interface.
+access(all) contract interface FungibleToken: ViewResolver {
+
+    // An entitlement for allowing the withdrawal of tokens from a Vault
+    access(all) entitlement Withdraw
+
+    /// The event that is emitted when tokens are withdrawn
+    /// from any Vault that implements the `Vault` interface
+    access(all) event Withdrawn(type: String,
+                                amount: UFix64,
+                                from: Address?,
+                                fromUUID: UInt64,
+                                withdrawnUUID: UInt64,
+                                balanceAfter: UFix64)
+
+    /// The event that is emitted when tokens are deposited to
+    /// any Vault that implements the `Vault` interface
+    access(all) event Deposited(type: String,
+                                amount: UFix64,
+                                to: Address?,
+                                toUUID: UInt64,
+                                depositedUUID: UInt64,
+                                balanceAfter: UFix64)
+
+    /// Event that is emitted when the global `Burner.burn()` method
+    /// is called with a non-zero balance
+    access(all) event Burned(type: String, amount: UFix64, fromUUID: UInt64)
+
+    /// Balance
+    ///
+    /// The interface that provides a standard field
+    /// for representing balance
+    ///
+    access(all) resource interface Balance: Burner.Burnable {
+        access(all) var balance: UFix64
+
+        // This default implementation needs to be in a separate interface
+        // from the one in `Vault` so that the conditions get enforced
+        // in the correct one
+        access(contract) fun burnCallback() {
+            self.balance = 0.0
+        }
+    }
+
+    /// Provider
+    ///
+    /// The interface that enforces the requirements for withdrawing
+    /// tokens from the implementing type.
+    ///
+    /// It does not enforce requirements on `balance` here,
+    /// because it leaves open the possibility of creating custom providers
+    /// that do not necessarily need their own balance.
+    ///
+    access(all) resource interface Provider {
+
+        /// Function to ask a provider if a specific amount of tokens
+        /// is available to be withdrawn
+        /// This could be useful to avoid panicking when calling withdraw
+        /// when the balance is unknown
+        /// Additionally, if the provider is pulling from multiple vaults
+        /// it only needs to check some of the vaults until the desired amount
+        /// is reached, potentially helping with performance.
+        ///
+        /// @param amount the amount of tokens requested to potentially withdraw
+        /// @return Bool Whether or not this amount is available to withdraw
+        /// 
+        access(all) view fun isAvailableToWithdraw(amount: UFix64): Bool
+
+        /// withdraw subtracts tokens from the implementing resource
+        /// and returns a Vault with the removed tokens.
+        ///
+        /// The function's access level is `access(Withdraw)`
+        /// So in order to access it, one would either need the object itself
+        /// or an entitled reference with `Withdraw`.
+        ///
+        /// @param amount the amount of tokens to withdraw from the resource
+        /// @return The Vault with the withdrawn tokens
+        ///
+        access(Withdraw) fun withdraw(amount: UFix64): @{Vault} {
+            post {
+                // `result` refers to the return value
+                result.balance == amount:
+                    "FungibleToken.Provider.withdraw: Cannot withdraw tokens! The balance of the withdrawn tokens (\(result.balance)) is not equal to the amount requested to be withdrawn (\(amount))"
+            }
+        }
+    }
+
+    /// Receiver
+    ///
+    /// The interface that enforces the requirements for depositing
+    /// tokens into the implementing type.
+    ///
+    /// We do not include a condition that checks the balance because
+    /// we want to give users the ability to make custom receivers that
+    /// can do custom things with the tokens, like split them up and
+    /// send them to different places.
+    ///
+    access(all) resource interface Receiver {
+
+        /// deposit takes a Vault and deposits it into the implementing resource type
+        ///
+        /// @param from the Vault that contains the tokens to deposit
+        ///
+        access(all) fun deposit(from: @{Vault})
+
+        /// getSupportedVaultTypes returns a dictionary of Vault types
+        /// and whether the type is currently supported by this Receiver
+        ///
+        /// @return {Type: Bool} A dictionary that indicates the supported types
+        ///                      If a type is not supported, it should be `nil`, not false
+        ///
+        access(all) view fun getSupportedVaultTypes(): {Type: Bool}
+
+        /// Returns whether or not the given type is accepted by the Receiver
+        /// A vault that can accept any type should just return true by default
+        ///
+        /// @param type The type to query about
+        /// @return Bool Whether or not the vault type is supported
+        ///
+        access(all) view fun isSupportedVaultType(type: Type): Bool
+    }
+
+    /// Vault
+    /// Conforms to all other interfaces so that implementations
+    /// only have to conform to `Vault`
+    ///
+    access(all) resource interface Vault: Receiver, Provider, Balance, ViewResolver.Resolver, Burner.Burnable {
+
+        /// Field that tracks the balance of a vault
+        access(all) var balance: UFix64
+
+        /// Called when a fungible token is burned via the `Burner.burn()` method
+        /// Implementations can do any bookkeeping or emit any events
+        /// that should be emitted when a vault is destroyed.
+        /// Many implementations will want to update the token's total supply
+        /// to reflect that the tokens have been burned and removed from the supply.
+        /// Implementations also need to set the balance to zero before the end of the function
+        /// This is to prevent vault owners from spamming fake Burned events.
+        access(contract) fun burnCallback() {
+            pre {
+                emit Burned(
+                    type: self.getType().identifier,
+                    amount: self.balance,
+                    fromUUID: self.uuid
+                )
+            }
+            post {
+                self.balance == 0.0:
+                    "FungibleToken.Vault.burnCallback: Cannot burn this `Vault` with `Burner.burn()`. The balance must be set to zero during the `burnCallback` method so that it cannot be spammed."
+            }
+        }
+
+        /// getSupportedVaultTypes
+        /// The default implementation is included here because vaults are expected
+        /// to only accepted their own type, so they have no need to provide an implementation
+        /// for this function
+        ///
+        access(all) view fun getSupportedVaultTypes(): {Type: Bool} {
+            // Below check is implemented to make sure that run-time type would
+            // only get returned when the parent resource conforms with `FungibleToken.Vault`. 
+            if self.getType().isSubtype(of: Type<@{FungibleToken.Vault}>()) {
+                return {self.getType(): true}
+            } else {
+                // Return an empty dictionary as the default value for resource who don't
+                // implement `FungibleToken.Vault`, such as `FungibleTokenSwitchboard`, `TokenForwarder` etc.
+                return {}
+            }
+        }
+
+        /// Checks if the given type is supported by this Vault
+        access(all) view fun isSupportedVaultType(type: Type): Bool {
+            return self.getSupportedVaultTypes()[type] ?? false
+        }
+
+        /// withdraw subtracts `amount` from the Vault's balance
+        /// and returns a new Vault with the subtracted balance
+        ///
+        access(Withdraw) fun withdraw(amount: UFix64): @{Vault} {
+            pre {
+                self.balance >= amount:
+                    "FungibleToken.Vault.withdraw: Cannot withdraw tokens! The amount requested to be withdrawn (\(amount)) is greater than the balance of the `Vault` (\(self.balance))."
+            }
+            post {
+                result.getType() == self.getType():
+                    "FungibleToken.Vault.withdraw: Cannot withdraw tokens! The withdraw method tried to return an incompatible `Vault` type <\(result.getType().identifier)>. It must return a `Vault` with the same type as self <\(self.getType().identifier)>."
+
+                // use the special function `before` to get the value of the `balance` field
+                // at the beginning of the function execution
+                //
+                self.balance == before(self.balance) - amount:
+                    "FungibleToken.Vault.withdraw: Cannot withdraw tokens! The sender's balance after the withdrawal (\(self.balance)) must be the difference of the previous balance (\(before(self.balance))) and the amount withdrawn (\(amount))"
+
+                emit Withdrawn(
+                        type: result.getType().identifier,
+                        amount: amount,
+                        from: self.owner?.address,
+                        fromUUID: self.uuid,
+                        withdrawnUUID: result.uuid,
+                        balanceAfter: self.balance
+                )
+            }
+        }
+
+        /// deposit takes a Vault and adds its balance to the balance of this Vault
+        ///
+        access(all) fun deposit(from: @{FungibleToken.Vault}) {
+            // Assert that the concrete type of the deposited vault is the same
+            // as the vault that is accepting the deposit
+            pre {
+                from.isInstance(self.getType()):
+                    "FungibleToken.Vault.deposit: Cannot deposit tokens! The type of the deposited tokens <\(from.getType().identifier)> has to be the same type as the `Vault` being deposited into <\(self.getType().identifier)>. Check that you are withdrawing and depositing to the correct paths in the sender and receiver accounts and that those paths hold the same `Vault` types."
+            }
+            post {
+                emit Deposited(
+                        type: before(from.getType().identifier),
+                        amount: before(from.balance),
+                        to: self.owner?.address,
+                        toUUID: self.uuid,
+                        depositedUUID: before(from.uuid),
+                        balanceAfter: self.balance
+                )
+                self.balance == before(self.balance) + before(from.balance):
+                    "FungibleToken.Vault.deposit: Cannot deposit tokens! The receiver's balance after the deposit (\(self.balance)) must be the sum of the previous balance (\(before(self.balance))) and the amount deposited (\(before(from.balance)))"
+            }
+        }
+
+        /// createEmptyVault allows any user to create a new Vault that has a zero balance
+        ///
+        /// @return A Vault of the same type that has a balance of zero
+        access(all) fun createEmptyVault(): @{Vault} {
+            post {
+                result.balance == 0.0:
+                    "FungibleToken.Vault.createEmptyVault: Empty `Vault` creation failed! The newly created `Vault` must have zero balance but it has a balance of \(result.balance)"
+
+                result.getType() == self.getType():
+                    "FungibleToken.Vault.createEmptyVault: Empty `Vault` creation failed! The type of the new `Vault` <\(result.getType().identifier)> has to be the same type as the `Vault` that created it <\(self.getType().identifier)>."
+            }
+        }
+    }
+
+    /// createEmptyVault allows any user to create a new Vault that has a zero balance
+    ///
+    /// @return A Vault of the requested type that has a balance of zero
+    access(all) fun createEmptyVault(vaultType: Type): @{FungibleToken.Vault} {
+        post {
+            result.balance == 0.0:
+                "FungibleToken.createEmptyVault: Empty `Vault` creation failed! The newly created `Vault` must have zero balance but it has a balance of \(result.balance)"
+
+            result.getType() == vaultType:
+                "FungibleToken.createEmptyVault: Empty `Vault` creation failed! The type of the new `Vault` <\(result.getType().identifier)> has to be the same as the type that was requested <\(vaultType.identifier)>."
+        }
+    }
+}

--- a/contracts/external/FungibleTokenMetadataViews.cdc
+++ b/contracts/external/FungibleTokenMetadataViews.cdc
@@ -1,0 +1,182 @@
+import "FungibleToken"
+import "MetadataViews"
+import "ViewResolver"
+
+/// This contract implements the metadata standard proposed
+/// in FLIP-1087.
+/// 
+/// Ref: https://github.com/onflow/flips/blob/main/application/20220811-fungible-tokens-metadata.md
+/// 
+/// Structs and resources can implement one or more
+/// metadata types, called views. Each view type represents
+/// a different kind of metadata.
+///
+access(all) contract FungibleTokenMetadataViews {
+
+    /// FTView wraps FTDisplay and FTVaultData, and is used to give a complete 
+    /// picture of a Fungible Token. Most Fungible Token contracts should 
+    /// implement this view.
+    ///
+    access(all) struct FTView {
+        access(all) let ftDisplay: FTDisplay?     
+        access(all) let ftVaultData: FTVaultData?
+        view init(
+            ftDisplay: FTDisplay?,
+            ftVaultData: FTVaultData?
+        ) {
+            self.ftDisplay = ftDisplay
+            self.ftVaultData = ftVaultData
+        }
+    }
+
+    /// Helper to get a FT view.
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A FTView struct
+    ///
+    access(all) fun getFTView(viewResolver: &{ViewResolver.Resolver}): FTView {
+        let maybeFTView = viewResolver.resolveView(Type<FTView>())
+        if let ftView = maybeFTView {
+            return ftView as! FTView
+        }
+        return FTView(
+            ftDisplay: self.getFTDisplay(viewResolver),
+            ftVaultData: self.getFTVaultData(viewResolver)
+        )
+    }
+
+    /// View to expose the information needed to showcase this FT. 
+    /// This can be used by applications to give an overview and 
+    /// graphics of the FT.
+    ///
+    access(all) struct FTDisplay {
+        /// The display name for this token.
+        ///
+        /// Example: "Flow"
+        ///
+        access(all) let name: String
+
+        /// The abbreviated symbol for this token.
+        ///
+        /// Example: "FLOW"
+        access(all) let symbol: String
+
+        /// A description the provides an overview of this token.
+        ///
+        /// Example: "The FLOW token is the native currency of the Flow network."
+        access(all) let description: String
+
+        /// External link to a URL to view more information about the fungible token.
+        access(all) let externalURL: MetadataViews.ExternalURL
+
+        /// One or more versions of the fungible token logo.
+        access(all) let logos: MetadataViews.Medias
+
+        /// Social links to reach the fungible token's social homepages.
+        /// Possible keys may be "instagram", "twitter", "discord", etc.
+        access(all) let socials: {String: MetadataViews.ExternalURL}
+
+        view init(
+            name: String,
+            symbol: String,
+            description: String,
+            externalURL: MetadataViews.ExternalURL,
+            logos: MetadataViews.Medias,
+            socials: {String: MetadataViews.ExternalURL}
+        ) {
+            self.name = name
+            self.symbol = symbol
+            self.description = description
+            self.externalURL = externalURL
+            self.logos = logos
+            self.socials = socials
+        }
+    }
+
+    /// Helper to get FTDisplay in a way that will return a typed optional.
+    /// 
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return An optional FTDisplay struct
+    ///
+    access(all) fun getFTDisplay(_ viewResolver: &{ViewResolver.Resolver}): FTDisplay? {
+        if let maybeDisplayView = viewResolver.resolveView(Type<FTDisplay>()) {
+            if let displayView = maybeDisplayView as? FTDisplay {
+                return displayView
+            }
+        }
+        return nil
+    }
+
+    /// View to expose the information needed store and interact with a FT vault.
+    /// This can be used by applications to setup a FT vault with proper 
+    /// storage and public capabilities.
+    ///
+    access(all) struct FTVaultData {
+        /// Path in storage where this FT vault is recommended to be stored.
+        access(all) let storagePath: StoragePath
+
+        /// Public path which must be linked to expose the public receiver capability.
+        access(all) let receiverPath: PublicPath
+
+        /// Public path which must be linked to expose the balance and resolver public capabilities.
+        access(all) let metadataPath: PublicPath
+
+        /// Type that should be linked at the `receiverPath`. This is a restricted type requiring 
+        /// the `FungibleToken.Receiver` interface.
+        access(all) let receiverLinkedType: Type
+
+        /// Type that should be linked at the `receiverPath`. This is a restricted type requiring 
+        /// the `ViewResolver.Resolver` interfaces.
+        access(all) let metadataLinkedType: Type
+
+        /// Function that allows creation of an empty FT vault that is intended
+        /// to store the funds.
+        access(all) let createEmptyVault: fun(): @{FungibleToken.Vault}
+
+        view init(
+            storagePath: StoragePath,
+            receiverPath: PublicPath,
+            metadataPath: PublicPath,
+            receiverLinkedType: Type,
+            metadataLinkedType: Type,
+            createEmptyVaultFunction: fun(): @{FungibleToken.Vault}
+        ) {
+            pre {
+                receiverLinkedType.isSubtype(of: Type<&{FungibleToken.Receiver}>()):
+                    "FungibleTokenMetadataViews.FTVaultData.init: Invalid receiverLinkedType. The receiver public type <\(receiverLinkedType.identifier)> must be a subtype of <\(Type<&{FungibleToken.Receiver}>().identifier)>."
+                metadataLinkedType.isSubtype(of: Type<&{FungibleToken.Vault}>()):
+                    "FungibleTokenMetadataViews.FTVaultData.init: Invalid metadataLinkedType. The metadata linked type <\(metadataLinkedType.identifier)> must be a subtype of <\(Type<&{FungibleToken.Vault}>().identifier)>."
+            }
+            self.storagePath = storagePath
+            self.receiverPath = receiverPath
+            self.metadataPath = metadataPath
+            self.receiverLinkedType = receiverLinkedType
+            self.metadataLinkedType = metadataLinkedType
+            self.createEmptyVault = createEmptyVaultFunction
+        }
+    }
+
+    /// Helper to get FTVaultData in a way that will return a typed Optional.
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional FTVaultData struct
+    ///
+    access(all) fun getFTVaultData(_ viewResolver: &{ViewResolver.Resolver}): FTVaultData? {
+        if let view = viewResolver.resolveView(Type<FTVaultData>()) {
+            if let v = view as? FTVaultData {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose the total supply of the Vault's token
+    access(all) struct TotalSupply {
+        access(all) let supply: UFix64
+
+        view init(totalSupply: UFix64) {
+            self.supply = totalSupply
+        }
+    }
+}
+ 

--- a/contracts/external/FungibleTokenSwitchboard.cdc
+++ b/contracts/external/FungibleTokenSwitchboard.cdc
@@ -1,0 +1,370 @@
+import "FungibleToken"
+
+/// The contract that allows an account to receive payments in multiple fungible
+/// tokens using a single `{FungibleToken.Receiver}` capability.
+/// This capability should ideally be stored at the 
+/// `FungibleTokenSwitchboard.ReceiverPublicPath = /public/GenericFTReceiver`
+/// but it can be stored anywhere.
+/// 
+access(all) contract FungibleTokenSwitchboard {
+  
+    // Storage and Public Paths
+    access(all) let StoragePath: StoragePath
+    access(all) let PublicPath: PublicPath
+    access(all) let ReceiverPublicPath: PublicPath
+
+    access(all) entitlement Owner
+
+    /// The event that is emitted when a new vault capability is added to a
+    /// switchboard resource.
+    access(all) event VaultCapabilityAdded(type: Type, switchboardOwner: Address?, capabilityOwner: Address?)
+
+    /// The event that is emitted when a vault capability is removed from a
+    /// switchboard resource.
+    access(all) event VaultCapabilityRemoved(type: Type, switchboardOwner: Address?, capabilityOwner: Address?)
+
+    /// The event that is emitted when a deposit can not be completed.
+    access(all) event NotCompletedDeposit(type: Type, amount: UFix64, switchboardOwner: Address?)
+
+    /// The interface that enforces the method to allow anyone to check on the
+    /// available capabilities of a switchboard resource and also exposes the 
+    /// deposit methods to deposit funds on it.
+    /// 
+    access(all) resource interface SwitchboardPublic {
+        access(all) view fun getVaultTypesWithAddress(): {Type: Address}
+        access(all) view fun getSupportedVaultTypes(): {Type: Bool}
+        access(all) view fun isSupportedVaultType(type: Type): Bool
+        access(all) fun deposit(from: @{FungibleToken.Vault})
+        access(all) fun safeDeposit(from: @{FungibleToken.Vault}): @{FungibleToken.Vault}?
+        access(all) view fun safeBorrowByType(type: Type): &{FungibleToken.Receiver}?
+    }
+
+    /// The resource that stores the multiple fungible token receiver 
+    /// capabilities, allowing the owner to add and remove them and anyone to 
+    /// deposit any fungible token among the available types.
+    /// 
+    access(all) resource Switchboard: FungibleToken.Receiver, SwitchboardPublic {
+       
+        /// Dictionary holding the fungible token receiver capabilities, 
+        /// indexed by the fungible token vault type.
+        /// 
+        access(contract) var receiverCapabilities: {Type: Capability<&{FungibleToken.Receiver}>}
+
+        /// Adds a new fungible token receiver capability to the switchboard 
+        /// resource.
+        /// 
+        /// @param capability: The capability to expose a certain fungible
+        /// token vault deposit function through `{FungibleToken.Receiver}` that
+        /// will be added to the switchboard.
+        /// 
+        access(Owner) fun addNewVault(capability: Capability<&{FungibleToken.Receiver}>) {
+            // Borrow a reference to the vault pointed to by the capability we 
+            // want to store inside the switchboard
+            let vaultRef = capability.borrow()
+                ?? panic("FungibleTokenSwitchboard.Switchboard.addNewVault: Cannot borrow reference to vault from capability. Make sure that the capability path points to a `Vault` that has been properly initialized.")
+
+            // Check if there is a previous capability for this token
+            if (self.receiverCapabilities[vaultRef.getType()] == nil) {
+                // use the vault reference type as key for storing the 
+                // capability and then
+                self.receiverCapabilities[vaultRef.getType()] = capability
+                // emit the event that indicates that a new capability has been 
+                // added
+                emit VaultCapabilityAdded(
+                    type: vaultRef.getType(),
+                    switchboardOwner: self.owner?.address,
+                    capabilityOwner: capability.address
+                )
+            } else {
+                // If there was already a capability for that token, panic
+                panic("FungibleTokenSwitchboard.Switchboard.addNewVault: Cannot add new `Vault` capability! There is already a vault in the `Switchboard` for this type <\(vaultRef.getType().identifier)>.")
+            }
+        }
+
+        /// Adds a number of new fungible token receiver capabilities by using
+        /// the paths where they are stored.
+        ///                    
+        /// @param paths: The paths where the public capabilities are stored.
+        /// @param address: The address of the owner of the capabilities.
+        /// 
+        access(Owner) fun addNewVaultsByPath(paths: [PublicPath], address: Address) {
+            // Get the account where the public capabilities are stored
+            let owner = getAccount(address)
+            // For each path, get the saved capability and store it 
+            // into the switchboard's receiver capabilities dictionary
+            for path in paths {
+                let capability = owner.capabilities.get<&{FungibleToken.Receiver}>(path)
+                // Borrow a reference to the vault pointed to by the capability
+                // we want to store inside the switchboard
+                // If the vault was borrowed successfully...
+                if let vaultRef = capability.borrow() {
+                    // ...and if there is no previous capability added for that token
+                    if (self.receiverCapabilities[vaultRef.getType()] == nil) {
+                        // Use the vault reference type as key for storing the
+                        // capability
+                        self.receiverCapabilities[vaultRef.getType()] = capability
+                        // and emit the event that indicates that a new
+                        // capability has been added
+                        emit VaultCapabilityAdded(
+                            type: vaultRef.getType(),
+                            switchboardOwner: self.owner?.address,
+                            capabilityOwner: address,
+                        )
+                    }
+                }
+            }
+        }
+
+        /// Adds a new fungible token receiver capability to the switchboard 
+        /// resource specifying which `Type` of `@{FungibleToken.Vault}` can be 
+        /// deposited to it. Use it to include in your switchboard "wrapper"
+        /// receivers such as a `@TokenForwarding.Forwarder`. It can also be
+        /// used to overwrite the type attached to a certain capability without 
+        /// having to remove that capability first.
+        ///
+        /// @param capability: The capability to expose a certain fungible
+        /// token vault deposit function through `{FungibleToken.Receiver}` that
+        /// will be added to the switchboard.
+        ///
+        /// @param type: The type of fungible token that can be deposited to that
+        /// capability, rather than the `Type` from the reference borrowed from
+        /// said capability
+        /// 
+        access(Owner) fun addNewVaultWrapper(capability: Capability<&{FungibleToken.Receiver}>,
+                                                                        type: Type) {
+            pre {
+                capability.check():
+                    "FungibleTokenSwitchboard.Switchboard.addNewVaultWrapper: Cannot borrow reference to a vault from the provided capability. Make sure that the capability path points to a Vault that has been properly initialized."
+            }
+            // Use the type parameter as key for the capability
+            self.receiverCapabilities[type] = capability
+            // emit the event that indicates that a new capability has been 
+            // added
+            emit VaultCapabilityAdded(
+                type: type,
+                switchboardOwner: self.owner?.address,
+                capabilityOwner: capability.address,
+            )
+        }
+
+        /// Adds zero or more new fungible token receiver capabilities to the  
+        /// switchboard resource specifying which `Type`s of `@{FungibleToken.Vault}`s  
+        /// can be deposited to it. Use it to include in your switchboard "wrapper"
+        /// receivers such as a `@TokenForwarding.Forwarder`. It can also be
+        /// used to overwrite the types attached to certain capabilities without 
+        /// having to remove those capabilities first.
+        ///                    
+        /// @param paths: The paths where the public capabilities are stored.
+        /// @param types: The types of the fungible token to be deposited on each path.
+        /// @param address: The address of the owner of the capabilities.
+        /// 
+        access(Owner) fun addNewVaultWrappersByPath(paths: [PublicPath], types: [Type],
+                                                                  address: Address) {
+            pre {
+                paths.length == types.length:
+                    "FungibleTokenSwitchboard.Switchboard.addNewVaultWrappersByPath: The paths and types arrays must be the same length. paths length: \(paths.length), types length: \(types.length)"
+            }
+            // Get the account where the public capabilities are stored
+            let owner = getAccount(address)
+            // For each path, get the saved capability and store it 
+            // into the switchboard's receiver capabilities dictionary
+            for i, path in paths {
+                let capability = owner.capabilities.get<&{FungibleToken.Receiver}>(path)
+                // Borrow a reference to the vault pointed to by the capability
+                // we want to store inside the switchboard
+                // If the vault was borrowed successfully...
+                if let vaultRef = capability.borrow() {
+                    // Use the vault reference type as key for storing the capability
+                    self.receiverCapabilities[types[i]] = capability
+                    // and emit the event that indicates that a new capability has been added
+                    emit VaultCapabilityAdded(
+                        type: types[i],
+                        switchboardOwner: self.owner?.address,
+                        capabilityOwner: address,
+                    )
+                }
+            }
+        }
+
+        /// Removes a fungible token receiver capability from the switchboard
+        /// resource.
+        /// 
+        /// @param capability: The capability to a fungible token vault to be
+        /// removed from the switchboard.
+        /// 
+        access(Owner) fun removeVault(capability: Capability<&{FungibleToken.Receiver}>) {
+            // Borrow a reference to the vault pointed to by the capability we 
+            // want to remove from the switchboard
+            let vaultRef = capability.borrow()
+                ?? panic("FungibleTokenSwitchboard.Switchboard.removeVault: Cannot borrow reference to a vault from the provided capability. Make sure that the capability path points to a `Vault` that has been properly initialized.")
+
+            // Use the vault reference to find the capability to remove
+            self.receiverCapabilities.remove(key: vaultRef.getType())
+            // Emit the event that indicates that a new capability has been 
+            // removed
+            emit VaultCapabilityRemoved(
+                type: vaultRef.getType(),
+                switchboardOwner: self.owner?.address,
+                capabilityOwner: capability.address,
+            )
+        }
+        
+        /// Takes a fungible token vault and routes it to the proper fungible 
+        /// token receiver capability for depositing it.
+        /// 
+        /// @param from: The deposited fungible token vault resource.
+        /// 
+        access(all) fun deposit(from: @{FungibleToken.Vault}) {
+            // Get the capability from the ones stored at the switchboard
+            let depositedVaultCapability = self.receiverCapabilities[from.getType()]
+                ?? panic("FungibleTokenSwitchboard.Switchboard.deposit: Cannot deposit `Vault`! The deposited vault of type <\(from.getType().identifier)> is not available on this Fungible Token `Switchboard`. The recipient needs to initialize their account and `Switchboard` to hold and receive the deposited vault type.")
+
+            // Borrow the reference to the desired vault
+            let vaultRef = depositedVaultCapability.borrow()
+                ?? panic("FungibleTokenSwitchboard.Switchboard.deposit: Cannot borrow reference to a vault from the type of the deposited `Vault` <\(from.getType().identifier)>. Make sure that the capability path points to a `Vault` that has been properly initialized.")
+
+            vaultRef.deposit(from: <-from)
+        }
+
+        /// Takes a fungible token vault and tries to route it to the proper
+        /// fungible token receiver capability for depositing the funds, 
+        /// avoiding panicking if the vault is not available.
+        ///             
+        /// @param vaultType: The type of the ft vault that wants to be 
+        /// deposited.
+        /// 
+        /// @return The deposited fungible token vault resource, without the
+        /// funds if the deposit was successful, or still containing the funds
+        /// if the reference to the needed vault was not found.
+        /// 
+        access(all) fun safeDeposit(from: @{FungibleToken.Vault}): @{FungibleToken.Vault}? {
+            // Try to get the proper vault capability from the switchboard
+            // If the desired vault is present on the switchboard...
+            if let depositedVaultCapability = self.receiverCapabilities[from.getType()] {
+                // We try to borrow a reference to the vault from the capability
+                // If we can borrow a reference to the vault...
+                if let vaultRef = depositedVaultCapability.borrow() {
+                    // We deposit the funds on said vault
+                    vaultRef.deposit(from: <-from.withdraw(amount: from.balance))
+                }
+            }
+            // if deposit failed for some reason
+            if from.balance > 0.0 {
+                emit NotCompletedDeposit(
+                    type: from.getType(),
+                    amount: from.balance,
+                    switchboardOwner: self.owner?.address,
+                )
+                return <-from
+            }
+            destroy from 
+            return nil
+        }
+
+        /// Checks that the capability tied to a type is valid.
+        ///
+        /// @param type: The type of the ft vault whose capability needs to be checked
+        ///
+        /// @return a boolean marking the capability for a type as valid or not
+        access(all) view fun checkReceiverByType(type: Type): Bool {
+            if let cap = self.receiverCapabilities[type] {
+                return cap.check()
+            }
+            return false
+        }
+
+        /// Gets the receiver assigned to a provided vault type.
+        /// This is necessary because without it, it is not possible to look under the hood and see if a capability
+        /// is of an expected type or not. This helps guard against infinitely chained TokenForwarding or other invalid
+        /// malicious kinds of updates that could prevent listings from being made that are valid on storefronts.
+        ///
+        /// @param type: The type of the ft vault whose capability needs to be checked
+        ///
+        /// @return an optional receiver capability for consumers of the switchboard to check/validate on their own
+        access(all) view fun safeBorrowByType(type: Type): &{FungibleToken.Receiver}? {
+            // Single dictionary lookup: returns nil if the type is not registered
+            // or if the capability is stale, without a separate check() + borrow() TOCTOU.
+            if let cap = self.receiverCapabilities[type] {
+                return cap.borrow()
+            }
+            return nil
+        }
+
+        /// A getter function to know which tokens a certain switchboard 
+        /// resource is prepared to receive along with the address where
+        /// those tokens will be deposited.
+        ///
+        /// @return A dictionary mapping the `{FungibleToken.Receiver}` 
+        /// type to the receiver owner's address 
+        ///
+        access(all) view fun getVaultTypesWithAddress(): {Type: Address} {
+            let effectiveTypesWithAddress: {Type: Address} = {}
+            // Iterate over key-value pairs to avoid double dictionary lookups per entry
+            for vaultType in self.receiverCapabilities.keys {
+                let cap = self.receiverCapabilities[vaultType]!
+                if cap.check() {
+                    effectiveTypesWithAddress[vaultType] = cap.address
+                }
+            }
+            return effectiveTypesWithAddress
+        }
+
+        /// A getter function that returns the token types supported by this resource,
+        /// which can be deposited using the 'deposit' function.
+        ///
+        /// @return Dictionary of FT types that can be deposited.
+        access(all) view fun getSupportedVaultTypes(): {Type: Bool} {
+            let supportedVaults: {Type: Bool} = {}
+            // Iterate over key-value pairs to avoid repeated dictionary lookups.
+            // Using borrow() instead of check() + borrow() eliminates the TOCTOU
+            // between the two calls and reduces the total number of capability operations.
+            for receiverType in self.receiverCapabilities.keys {
+                let cap = self.receiverCapabilities[receiverType]!
+                if let receiverRef = cap.borrow() {
+                    // Direct vault types are added as-is
+                    if receiverType.isSubtype(of: Type<@{FungibleToken.Vault}>()) {
+                        supportedVaults[receiverType] = true
+                    }
+                    // Wrapper receivers (e.g. TokenForwarding.Forwarder) are not Vault subtypes,
+                    // but they implement Receiver — recurse into their supported types to find
+                    // the underlying vault types they accept.
+                    if receiverType.isSubtype(of: Type<@{FungibleToken.Receiver}>()) {
+                        let subTypes = receiverRef.getSupportedVaultTypes()
+                        for subReceiverType in subTypes {
+                            let supported = subTypes[subReceiverType]!
+                            if supported && subReceiverType.isSubtype(of: Type<@{FungibleToken.Vault}>()) {
+                                supportedVaults[subReceiverType] = true
+                            }
+                        }
+                    }
+                }
+            }
+            return supportedVaults
+        }
+
+        /// Returns whether or not the given type is accepted by the Receiver.
+        /// A vault that can accept any type should just return true by default.
+        access(all) view fun isSupportedVaultType(type: Type): Bool {
+            return self.getSupportedVaultTypes()[type] ?? false
+        }
+
+        init() {
+            // Initialize the capabilities dictionary
+            self.receiverCapabilities = {}
+        }
+
+    }
+
+    /// Function that allows to create a new blank switchboard. A user must call
+    /// this function and store the returned resource in their storage.
+    ///
+    access(all) fun createSwitchboard(): @Switchboard {
+        return <-create Switchboard()
+    }
+
+    init() {
+        self.StoragePath = /storage/fungibleTokenSwitchboard
+        self.PublicPath = /public/fungibleTokenSwitchboardPublic
+        self.ReceiverPublicPath = /public/GenericFTReceiver
+    }
+}

--- a/contracts/external/IFlowEVMNFTBridge.cdc
+++ b/contracts/external/IFlowEVMNFTBridge.cdc
@@ -1,0 +1,118 @@
+import "FungibleToken"
+import "NonFungibleToken"
+
+import "EVM"
+
+import "FlowEVMBridgeConfig"
+import "CrossVMNFT"
+
+access(all) contract interface IFlowEVMNFTBridge {
+    
+    /*************
+        Events
+    **************/
+
+    /// Broadcasts an NFT was bridged from Cadence to EVM
+    access(all)
+    event BridgedNFTToEVM(
+        type: String,
+        id: UInt64,
+        uuid: UInt64,
+        evmID: UInt256,
+        to: String,
+        evmContractAddress: String,
+        bridgeAddress: Address
+    )
+    /// Broadcasts an NFT was bridged from EVM to Cadence
+    access(all)
+    event BridgedNFTFromEVM(
+        type: String,
+        id: UInt64,
+        uuid: UInt64,
+        evmID: UInt256,
+        caller: String,
+        evmContractAddress: String,
+        bridgeAddress: Address
+    )
+
+    /**************
+        Getters
+    ***************/
+
+    /// Returns the EVM address associated with the provided type
+    ///
+    access(all)
+    view fun getAssociatedEVMAddress(with type: Type): EVM.EVMAddress?
+
+    /// Returns the EVM address of the bridge coordinating COA
+    ///
+    access(all)
+    view fun getBridgeCOAEVMAddress(): EVM.EVMAddress
+
+    /********************************
+        Public Bridge Entrypoints
+    *********************************/
+
+    /// Public entrypoint to bridge NFTs from Cadence to EVM.
+    ///
+    /// @param token: The NFT to be bridged
+    /// @param to: The NFT recipient in FlowEVM
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    ///
+    access(all)
+    fun bridgeNFTToEVM(
+        token: @{NonFungibleToken.NFT},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        pre {
+            emit BridgedNFTToEVM(
+                type: token.getType().identifier,
+                id: token.id,
+                uuid: token.uuid,
+                evmID: CrossVMNFT.getEVMID(from: &token as &{NonFungibleToken.NFT}) ?? UInt256(token.id),
+                to: to.toString(),
+                evmContractAddress: self.getAssociatedEVMAddress(with: token.getType())?.toString()
+                    ?? panic(
+                        "Could not find EVM Contract address associated with provided NFT identifier=\(token.getType().identifier)"
+                    ),
+                bridgeAddress: self.account.address
+            )
+        }
+    }
+
+    /// Public entrypoint to bridge NFTs from EVM to Cadence
+    ///
+    /// @param owner: The EVM address of the NFT owner. Current ownership and successful transfer (via 
+    ///     `protectedTransferCall`) is validated before the bridge request is executed.
+    /// @param type: The Cadence Type of the NFT to be bridged. If EVM-native, this would be the Cadence Type associated
+    ///     with the EVM contract on the Flow side at onboarding.
+    /// @param id: The NFT ID to bridged
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    /// @param protectedTransferCall: A function that executes the transfer of the NFT from the named owner to the
+    ///     bridge's COA. This function is expected to return a Result indicating the status of the transfer call.
+    ///
+    /// @returns The bridged NFT
+    ///
+    access(account)
+    fun bridgeNFTFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        id: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (EVM.EVMAddress): EVM.ResultDecoded
+    ): @{NonFungibleToken.NFT} {
+        post {
+            emit BridgedNFTFromEVM(
+                type: result.getType().identifier,
+                id: result.id,
+                uuid: result.uuid,
+                evmID: id,
+                caller: owner.toString(),
+                evmContractAddress: self.getAssociatedEVMAddress(with: result.getType())?.toString()
+                    ?? panic("Could not find EVM Contract address associated with provided NFT"),
+                bridgeAddress: self.account.address
+            )
+        }
+    }
+}

--- a/contracts/external/IFlowEVMTokenBridge.cdc
+++ b/contracts/external/IFlowEVMTokenBridge.cdc
@@ -1,0 +1,111 @@
+import "FungibleToken"
+import "NonFungibleToken"
+
+import "EVM"
+
+access(all) contract interface IFlowEVMTokenBridge {
+    
+    /*************
+        Events
+    **************/
+
+    /// Broadcasts fungible tokens were bridged from Cadence to EVM
+    access(all)
+    event BridgedTokensToEVM(
+        type: String,
+        amount: UFix64,
+        bridgedUUID: UInt64,
+        to: String,
+        evmContractAddress: String,
+        bridgeAddress: Address
+    )
+    /// Broadcasts fungible tokens were bridged from EVM to Cadence
+    access(all)
+    event BridgedTokensFromEVM(
+        type: String,
+        amount: UInt256,
+        bridgedUUID: UInt64,
+        caller: String,
+        evmContractAddress: String,
+        bridgeAddress: Address
+    )
+
+    /**************
+        Getters
+    ***************/
+
+    /// Returns the EVM address associated with the provided type
+    ///
+    access(all)
+    view fun getAssociatedEVMAddress(with type: Type): EVM.EVMAddress?
+
+    /// Returns the EVM address of the bridge coordinating COA
+    ///
+    access(all)
+    view fun getBridgeCOAEVMAddress(): EVM.EVMAddress
+
+    /********************************
+        Public Bridge Entrypoints
+    *********************************/
+
+    /// Public entrypoint to bridge fungible tokens from Cadence to EVM.
+    ///
+    /// @param token: The token Vault to be bridged
+    /// @param to: The token recipient in EVM
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    ///
+    access(all)
+    fun bridgeTokensToEVM(
+        vault: @{FungibleToken.Vault},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        pre {
+            emit BridgedTokensToEVM(
+                type: vault.getType().identifier,
+                amount: vault.balance,
+                bridgedUUID: vault.uuid,
+                to: to.toString(),
+                evmContractAddress: self.getAssociatedEVMAddress(with: vault.getType())?.toString()
+                    ?? panic(
+                        "Could not find EVM Contract address associated with provided Token identifier=\(vault.getType().identifier)"
+                    ),
+                bridgeAddress: self.account.address
+            )
+        }
+    }
+
+    /// Public entrypoint to bridge fungible tokens from EVM to Cadence
+    ///
+    /// @param owner: The EVM address of the token owner. Current ownership and successful transfer (via 
+    ///     `protectedTransferCall`) is validated before the bridge request is executed.
+    /// @param type: The Cadence Type of the fungible token to be bridged. If EVM-native, this would be the Cadence
+    ///     Type associated with the EVM contract on the Flow side at onboarding.
+    /// @param amount: The amount of tokens to bridge from EVM to Cadence
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    /// @param protectedTransferCall: A function that executes the transfer of the NFT from the named owner to the
+    ///     bridge's COA. This function is expected to return a Result indicating the status of the transfer call.
+    ///
+    /// @returns The bridged NFT
+    ///
+    access(account)
+    fun bridgeTokensFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        amount: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (): EVM.ResultDecoded
+    ): @{FungibleToken.Vault} {
+        post {
+            emit BridgedTokensFromEVM(
+                type: result.getType().identifier,
+                amount: amount,
+                bridgedUUID: result.uuid,
+                caller: owner.toString(),
+                evmContractAddress: self.getAssociatedEVMAddress(with: result.getType())?.toString()
+                    ?? panic("Could not find EVM Contract address associated with provided Vault"),
+                bridgeAddress: self.account.address
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR shows the **exact diff between what is currently deployed on Flow mainnet and what will be deployed** in the upcoming contract upgrade. It covers all 27 contracts across 3 repositories.

**How to review:** Each file in this PR shows the change from the mainnet-deployed version (base) to the target upgrade version (head). The `contracts/external/` directory contains contracts from other repos (flow-ft, flow-evm-bridge) for completeness.

## Contracts by Risk Level

### 🔴 SUBSTANTIVE — Logic/behavior changes

| Contract | Change | Risk |
|----------|--------|------|
| **FlowFees** | **New child fee accounts feature** — fee collection distributed across child accounts, withdrawal aggregates across accounts | **High** |
| **FlowIDTableStaking** | Division-by-zero fix in reward calculation when all nodes non-operational + `.keys` → direct dict iteration | Medium |
| **FungibleTokenSwitchboard** | New `paths.length == types.length` validation, TOCTOU fix (`check()+borrow()` → `borrow()`), force-unwrap elimination | Medium |
| **FlowStakingCollection** | `saturatingSubtract` prevents underflow panic when vault balance < minimum storage reservation (3 occurrences) | Low-Medium |
| **FlowTransactionScheduler** | Binary search `break` on duplicate canceled ID, `.keys` → direct iteration | Low |
| **FlowTransactionSchedulerUtils** | Force-unwrap → safe unwrap (`index!` → `if let index`) | Low |
| **FlowEVMBridge** | `EVM.Result` → `EVM.ResultDecoded`, `call` → `callWithSigAndArgs`, new pause check for custom/updated types | Medium |
| **FlowEVMBridgeAccessor** | EVM API migration + dust precision fix (`castERC20AmountToCadencePrecision`) | Medium |
| **FlowEVMBridgeUtils** | `dryCall` → `dryCallWithSigAndArgs`, all `EVM.decodeABI` → `callResult.results`, new function, security docs | Medium |
| **FlowEVMBridgeHandlers** | EVM API migration (`call` → `callWithSigAndArgs`, `Result` → `ResultDecoded`) | Medium |
| **FlowEVMBridgeCustomAssociations** | Error message logic fix (used wrong variable) | Low |

### ✅ COSMETIC — Error messages, comments, formatting only

| Contract | Change |
|----------|--------|
| **FungibleToken** | `.concat()` → `\()` string interpolation, "panicing" → "panicking" typo |
| **FungibleTokenMetadataViews** | Error message improvements |
| **FlowExecutionParameters** | Comment-only changes |
| **FlowEVMBridgeConfig** | Comment/doc changes |
| **StakingProxy** | Error message improvements |
| **FlowDKG** | Error message improvements |
| **FlowClusterQC** | Error message improvements + quorum threshold comments |
| **FlowEpoch** | Error message improvements + safety comments |
| **NodeVersionBeacon** | Error message improvements |
| **RandomBeaconHistory** | Error message improvements |
| **FlowServiceAccount** | Error message improvements |
| **LockedTokens** | Error message improvements |
| **FlowToken** | Error message improvements + performance optimization comments |
| **FlowEVMBridgeHandlerInterfaces** | TBD |
| **IFlowEVMNFTBridge** | TBD |
| **IFlowEVMTokenBridge** | TBD |

## Source Repositories

| Contracts | Source | Branch |
|-----------|--------|--------|
| Core contracts (FlowToken, FlowFees, FlowIDTableStaking, etc.) | `onflow/flow-core-contracts` | `master` |
| FungibleToken, FungibleTokenSwitchboard, FungibleTokenMetadataViews | `onflow/flow-ft` | `master` |
| FlowEVMBridge*, IFlowEVM* | `onflow/flow-evm-bridge` | `main` |

## Mainnet Addresses

| Address | Contracts |
|---------|-----------|
| `0x8624b52f9ddcd04a` | FlowIDTableStaking, FlowClusterQC, FlowDKG, FlowEpoch |
| `0xe467b9dd11fa00df` | FlowServiceAccount, NodeVersionBeacon, RandomBeaconHistory, FlowTransactionScheduler, FlowTransactionSchedulerUtils |
| `0xf919ee77447b7497` | FlowFees |
| `0x1654653399040a61` | FlowToken |
| `0x8d0e87b65159ae63` | LockedTokens, FlowStakingCollection |
| `0x62430cf28c26d095` | StakingProxy |
| `0xf426ff57ee8f6110` | FlowExecutionParameters |
| `0xf233dcee88fe0abe` | FungibleToken, FungibleTokenSwitchboard, FungibleTokenMetadataViews |
| `0x1e4aa0b87d10b141` | FlowEVMBridge + all bridge contracts |

## ⚠️ Key Items for Reviewers

1. **FlowFees** has the largest and highest-risk change — a completely new child fee accounts feature that changes how every transaction fee is collected and withdrawn
2. **Bridge contracts** all migrate from `EVM.Result`/`call()` to `EVM.ResultDecoded`/`callWithSigAndArgs()` — this must be coordinated with a compatible EVM contract version
3. **FlowStakingCollection** fixes a potential underflow panic with `saturatingSubtract`
4. **FlowIDTableStaking** fixes a division-by-zero edge case in reward calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)