### PR TITLE
Fix wildcard import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,5 @@ jobs:
         run: flow version
       - name: Update PATH
         run: echo "/root/.local/bin" >> $GITHUB_PATH
-      - name: Install Flow CLI
-        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)"
       - name: Run Go and Cadence tests
         run: make ci

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ generate:
 .PHONY: ci
 ci:
 	$(MAKE) ci -C lib/go
-	flow test --cover --covercode="contracts" tests/*_test.cdc
+	flow test --cover --covercode="contracts" --jobs 1 tests/*_test.cdc

--- a/lib/go/contracts/contracts.go
+++ b/lib/go/contracts/contracts.go
@@ -336,8 +336,12 @@ func LinearCodeAddressGenerator() []byte {
 func TESTFlowIDTableStaking(fungibleTokenAddress, flowTokenAddress string) []byte {
 	code := assets.MustAssetString(TESTFlowIdentityTableFilename)
 
-	code = strings.ReplaceAll(code, placeholderFungibleTokenAddress, withHexPrefix(fungibleTokenAddress))
-	code = strings.ReplaceAll(code, placeholderFlowTokenAddress, withHexPrefix(flowTokenAddress))
+	env := templates.Environment{
+		FungibleTokenAddress: fungibleTokenAddress,
+		FlowTokenAddress:     flowTokenAddress,
+	}
+
+	code = templates.ReplaceAddresses(code, env)
 
 	return []byte(code)
 }


### PR DESCRIPTION
Wildcard imports of addresses are no longer allowed in Cadence.

A test function was still producing a wildcard import. See e.g. https://github.com/onflow/cadence/actions/runs/24604569360/job/71948618174#step:5:968.

Fix the helper function to produce a full-qualified import.

While at it, also remove the duplicate step of installing the Flow CLI in CI.