### PR TITLE
Fix expected FungibleToken withdraw error in COA scheduler test

### DIFF
--- a/tests/transactionScheduler_coa_test.cdc
+++ b/tests/transactionScheduler_coa_test.cdc
@@ -360,7 +360,7 @@ access(all) fun testCOAScheduledTransactions() {
     executeScheduledTransaction(
         id: 6,
         testName: "Test COA Transaction Scheduling: Deposit too much FLOW and revert",
-        failWithErr: "is greater than the balance of the Vault"
+        failWithErr: "is greater than the balance of the `Vault`"
     )
 
     executeScheduledTransaction(


### PR DESCRIPTION

CI fails deterministically on `testCOAScheduledTransactions` (e.g. [this run](https://github.com/onflow/flow-core-contracts/actions/runs/30103458417) on #615), on any branch, including master.

CI installs the latest Flow CLI, currently v2.17.4, which bundles a FungibleToken standard whose `withdraw` pre-condition message wraps the type name in backticks:

> ... is greater than the balance of the `` `Vault` `` (9950.00000000)

The test asserts the old wording (`balance of the Vault`, no backticks), so the substring no longer matches. The wording changed in onflow/flow-ft#189 and reached CI via the emulator bundled in the flow-cli v2.17.4 release.
